### PR TITLE
Add explicit unsandboxed execution permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,6 +2228,7 @@ name = "local-mcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "codex-linux-sandbox",
  "codex-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,6 +2239,7 @@ dependencies = [
  "openssl",
  "serde",
  "serde_json",
+ "similar",
  "tokio",
  "uuid",
 ]
@@ -3804,6 +3805,12 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ dirs = "6"
 openssl = { version = "0.10", features = ["vendored"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread"] }
+similar = "2"
+tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "time"] }
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ jobs = 4
 
 [dependencies]
 anyhow = "1"
+base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 codex-linux-sandbox = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
 codex-protocol = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # local-mcp
 
 `local-mcp` exposes basic local-machine capabilities as MCP tools: file reads,
-directory listings, sandboxed file writes, sandboxed command execution, and
-explicitly approved HTTP requests. It intentionally does not provide web search.
+directory listings, sandboxed file writes and commands, plus explicitly approved
+unsandboxed command execution. It intentionally does not provide web search or a
+dedicated network-request tool.
 
 Commands are isolated with OpenAI Codex's `codex-rs/sandboxing` and Linux sandbox
 helper. Network access is denied for ordinary commands.
@@ -15,13 +16,19 @@ cargo build --release
 # Add this command as a stdio MCP server (the `mcp` argument is optional):
 local-mcp mcp
 
-# In another terminal, handle calls which need one-time approval:
+# In another terminal, approve unsandboxed calls:
 local-mcp approvals
+
+# In the approvals UI, allow every unsandboxed call until it exits:
+/permissions yolo
 
 # Trust sandboxed writes/commands rooted in a directory without prompting:
 local-mcp permit ./some-project
 local-mcp permits
 local-mcp revoke ./some-project
+
+# Set the cwd used when tools omit cwd and for relative file paths:
+local-mcp set-cwd ./some-project
 ```
 
 With Nix, `bwrap` and `curl` are included in the runtime environment:
@@ -32,10 +39,11 @@ nix develop
 nix build
 ```
 
-Permanent permits are canonical directory paths stored under the platform's
-local state directory. They do not enable network access. `network_request`
-always asks the `approvals` process and executes `curl` with network enabled only
-for that one sandboxed process.
+Sandboxed calls are always allowed and have no network access. `without_sandbox`
+runs with the service user's full host permissions and network access, so it asks
+the approvals process before every call. `/permissions yolo` disables those
+prompts only for the lifetime of that approvals process; `/permissions ask`
+turns prompts back on. The singular `/permission ...` spelling is also accepted.
 
 Approval requests use a permission-restricted Unix domain socket. Both the MCP
 server and the approval UI block on I/O, so idle operation and pending approvals

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Each session uses its own permission-restricted Unix domain socket. Both the MCP
 server and the start UI block on I/O, so idle operation and pending approvals
 do not use polling timers.
 
+The `start` screen also receives live activity from MCP calls. It shows file and
+image reads, directory listings, file edits with unified diffs and line counts,
+and command start/completion with output, in a compact Codex-style timeline.
+`execute` returns its normal result for commands that finish within 30 seconds.
+Longer commands continue in the background and return a `job_id`; use `poll_job`
+to check for completion or `stop_job` to terminate them. Use `start_command`
+when a command should run in the background immediately without the 30-second
+foreground wait.
+
 The build produces `local-mcp` and its sibling `codex-linux-sandbox`; install or
 copy both into the same directory. On Linux, `bwrap` (bubblewrap) must be
 available in `PATH`. macOS/Windows support is not implemented yet.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ local-mcp start
 # Give the printed session ID to the agent in your prompt. The agent includes it
 # in each local-mcp tool call.
 
-# In the approvals UI, allow every unsandboxed call until it exits:
+# In the approvals UI, allow every unsandboxed call for the session:
 /permissions yolo
 
 # Manage the current session from the start screen:
@@ -32,9 +32,10 @@ local-mcp start
 /permission allow ../another-project
 /permission revoke ../another-project
 /permission list
+/permission status
 ```
 
-With Nix, `bwrap` and `curl` are included in the runtime environment:
+With Nix, `bwrap`, `curl`, and `bash` are included in the runtime environment:
 
 ```sh
 nix run github:OWNER/local-mcp

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # local-mcp
 
 `local-mcp` exposes basic local-machine capabilities as MCP tools: file reads,
-directory listings, sandboxed file writes and commands, plus explicitly approved
+image reads, directory listings, sandboxed file writes and commands, plus explicitly approved
 unsandboxed command execution. It intentionally does not provide web search or a
 dedicated network-request tool.
 
@@ -13,22 +13,22 @@ helper. Network access is denied for ordinary commands.
 ```sh
 cargo build --release
 
-# Add this command as a stdio MCP server (the `mcp` argument is optional):
-local-mcp mcp
+# Start a session in the project directory:
+cd ./some-project
+local-mcp start
 
-# In another terminal, approve unsandboxed calls:
-local-mcp approvals
+# Give the printed session ID to the agent and use it in the MCP command:
+local-mcp mcp <SESSION_ID>
 
 # In the approvals UI, allow every unsandboxed call until it exits:
 /permissions yolo
 
-# Trust sandboxed writes/commands rooted in a directory without prompting:
-local-mcp permit ./some-project
-local-mcp permits
-local-mcp revoke ./some-project
-
-# Set the cwd used when tools omit cwd and for relative file paths:
-local-mcp set-cwd ./some-project
+# Manage the current session from the start screen:
+/permission ask
+/permission yolo
+/permission allow ../another-project
+/permission revoke ../another-project
+/permission list
 ```
 
 With Nix, `bwrap` and `curl` are included in the runtime environment:
@@ -39,14 +39,20 @@ nix develop
 nix build
 ```
 
-Sandboxed calls are always allowed and have no network access. `without_sandbox`
+The session working directory is the directory where `local-mcp start` was run;
+there is no separate persistent cwd setting. Sandboxed calls are always allowed
+and have no network access. `without_sandbox`
 runs with the service user's full host permissions and network access, so it asks
 the approvals process before every call. `/permissions yolo` disables those
-prompts only for the lifetime of that approvals process; `/permissions ask`
+prompts only for the lifetime of that session; `/permissions ask`
 turns prompts back on. The singular `/permission ...` spelling is also accepted.
+The agent can call `session_info` to confirm the session ID, working directory,
+and sandbox roots associated with its MCP connection.
+`get_image` returns PNG, JPEG, GIF, WebP, BMP, TIFF, and AVIF files as native MCP
+image content. Relative image paths are resolved from the session working directory.
 
-Approval requests use a permission-restricted Unix domain socket. Both the MCP
-server and the approval UI block on I/O, so idle operation and pending approvals
+Each session uses its own permission-restricted Unix domain socket. Both the MCP
+server and the start UI block on I/O, so idle operation and pending approvals
 do not use polling timers.
 
 The build produces `local-mcp` and its sibling `codex-linux-sandbox`; install or

--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ helper. Network access is denied for ordinary commands.
 ```sh
 cargo build --release
 
-# Start a session in the project directory:
+# Run one persistent MCP server (for example through a tunnel):
+local-mcp mcp
+
+# In another terminal, start a session in the project directory:
 cd ./some-project
 local-mcp start
 
-# Give the printed session ID to the agent and use it in the MCP command:
-local-mcp mcp <SESSION_ID>
+# Give the printed session ID to the agent in your prompt. The agent includes it
+# in each local-mcp tool call.
 
 # In the approvals UI, allow every unsandboxed call until it exits:
 /permissions yolo
@@ -46,8 +49,10 @@ runs with the service user's full host permissions and network access, so it ask
 the approvals process before every call. `/permissions yolo` disables those
 prompts only for the lifetime of that session; `/permissions ask`
 turns prompts back on. The singular `/permission ...` spelling is also accepted.
-The agent can call `session_info` to confirm the session ID, working directory,
-and sandbox roots associated with its MCP connection.
+Every tool takes a `session_id`. The agent can call `session_info` with the ID
+from the prompt to confirm the working directory and sandbox roots. One
+`local-mcp mcp` process can therefore serve multiple independently configured
+sessions.
 `get_image` returns PNG, JPEG, GIF, WebP, BMP, TIFF, and AVIF files as native MCP
 image content. Relative image paths are resolved from the session working directory.
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
             version = "0.1.0";
             src = self;
 
-            cargoHash = "sha256-2ub6LqGq4kOr6rXTcPuo4ND0RMoy82Ccl1rGPHpVza8=";
+            cargoHash = "sha256-NKZJzA/ZmIw7J0gKRjDe3+4ccLa9kTlpGv7oWrnfZ6o=";
 
             nativeBuildInputs = with pkgs; [
               cmake

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
             version = "0.1.0";
             src = self;
 
-            cargoHash = "sha256-NKZJzA/ZmIw7J0gKRjDe3+4ccLa9kTlpGv7oWrnfZ6o=";
+            cargoHash = "sha256-oOZrW9kqHT/R/fO+EFfBWOGhA9Y2dznRPQHBc5HivIg=";
 
             nativeBuildInputs = with pkgs; [
               cmake

--- a/src/approvals.rs
+++ b/src/approvals.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
@@ -71,30 +72,81 @@ pub async fn run_ui() -> Result<()> {
         .with_context(|| format!("failed to listen at {}", path.display()))?;
     tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await?;
     eprintln!(
-        "Waiting for local-mcp approval requests at {}. Press Ctrl-C to stop.",
+        "Waiting for local-mcp approval requests at {}.\n\
+         Commands: /permissions yolo (allow all), /permissions ask (ask each time).\n\
+         Press Ctrl-C to stop.",
         path.display()
     );
     let mut input = BufReader::new(tokio::io::stdin()).lines();
+    let mut pending = VecDeque::<(Request, UnixStream)>::new();
+    let mut yolo = false;
 
     loop {
-        let (mut stream, _) = listener.accept().await?;
-        let mut line = String::new();
-        BufReader::new(&mut stream).read_line(&mut line).await?;
-        let request: Request = serde_json::from_str(&line).context("invalid approval request")?;
-        eprintln!(
-            "\n[{}] {}\ncwd: {}\n{}",
-            request.id,
-            request.operation,
-            request.cwd.display(),
-            request.detail
-        );
-        eprint!("Allow once? [y/N] ");
-        std::io::stderr().flush()?;
-        let allowed = input.next_line().await?.is_some_and(|line| {
-            line.trim().eq_ignore_ascii_case("y") || line.trim().eq_ignore_ascii_case("yes")
-        });
-        stream
-            .write_all(if allowed { b"allow\n" } else { b"deny\n" })
-            .await?;
+        tokio::select! {
+            connection = listener.accept() => {
+                let (mut stream, _) = connection?;
+                let mut line = String::new();
+                BufReader::new(&mut stream).read_line(&mut line).await?;
+                let request: Request = serde_json::from_str(&line).context("invalid approval request")?;
+                if yolo {
+                    eprintln!("[yolo] allowing {}: {}", request.operation, request.detail);
+                    stream.write_all(b"allow\n").await?;
+                } else {
+                    show_request(&request)?;
+                    pending.push_back((request, stream));
+                }
+            }
+            line = input.next_line() => {
+                let Some(line) = line? else {
+                    anyhow::bail!("approval input closed");
+                };
+                match line.trim() {
+                    "/permissions yolo" | "/permission yolo" => {
+                        yolo = true;
+                        eprintln!("Permissions: yolo (all unsandboxed calls are allowed until this process exits)");
+                        while let Some((request, mut stream)) = pending.pop_front() {
+                            eprintln!("[yolo] allowing {}: {}", request.operation, request.detail);
+                            stream.write_all(b"allow\n").await?;
+                        }
+                    }
+                    "/permissions ask" | "/permission ask" => {
+                        yolo = false;
+                        eprintln!("Permissions: ask");
+                    }
+                    "y" | "Y" | "yes" | "YES" if !pending.is_empty() => {
+                        let (_, mut stream) = pending.pop_front().unwrap();
+                        stream.write_all(b"allow\n").await?;
+                        show_next(&pending)?;
+                    }
+                    _ if !pending.is_empty() => {
+                        let (_, mut stream) = pending.pop_front().unwrap();
+                        stream.write_all(b"deny\n").await?;
+                        show_next(&pending)?;
+                    }
+                    "" => {}
+                    command => eprintln!("Unknown command: {command}"),
+                }
+            }
+        }
     }
+}
+
+fn show_request(request: &Request) -> Result<()> {
+    eprintln!(
+        "\n[{}] {}\ncwd: {}\n{}",
+        request.id,
+        request.operation,
+        request.cwd.display(),
+        request.detail
+    );
+    eprint!("Allow without sandbox? [y/N] ");
+    std::io::stderr().flush()?;
+    Ok(())
+}
+
+fn show_next(pending: &VecDeque<(Request, UnixStream)>) -> Result<()> {
+    if let Some((request, _)) = pending.front() {
+        show_request(request)?;
+    }
+    Ok(())
 }

--- a/src/approvals.rs
+++ b/src/approvals.rs
@@ -61,12 +61,11 @@ pub async fn start() -> Result<()> {
     tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await?;
     eprintln!(
         "local-mcp session: {}\ncwd: {}\n\
-         Give this session ID to the agent and run: local-mcp mcp {}\n\
+         Give this session ID to the agent so it can include it in local-mcp tool calls.\n\
          Commands: /permission ask|yolo|allow <directory>|revoke <directory>|list|status\n\
          Press Ctrl-C to stop.",
         session.id,
-        session.cwd.display(),
-        session.id
+        session.cwd.display()
     );
 
     let mut input = BufReader::new(tokio::io::stdin()).lines();

--- a/src/approvals.rs
+++ b/src/approvals.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use uuid::Uuid;
 
-use crate::config;
+use crate::config::{self, Session};
 
 #[derive(Serialize, Deserialize)]
 pub struct Request {
@@ -19,24 +19,22 @@ pub struct Request {
     pub cwd: PathBuf,
 }
 
-fn socket_path() -> Result<PathBuf> {
-    Ok(config::state_dir()?.join("approvals.sock"))
-}
-
-pub async fn request(operation: &str, detail: String, cwd: PathBuf) -> Result<bool> {
+pub async fn request(
+    session_id: Uuid,
+    operation: &str,
+    detail: String,
+    cwd: PathBuf,
+) -> Result<bool> {
     let request = Request {
         id: Uuid::new_v4(),
         operation: operation.to_owned(),
         detail,
         cwd,
     };
-    let path = socket_path()?;
-    let mut stream = UnixStream::connect(&path).await.with_context(|| {
-        format!(
-            "approval service is unavailable; run `local-mcp approvals` (socket: {})",
-            path.display()
-        )
-    })?;
+    let path = config::socket_path(session_id)?;
+    let mut stream = UnixStream::connect(&path)
+        .await
+        .with_context(|| format!("session {session_id} is not running; run `local-mcp start`"))?;
     stream.write_all(&serde_json::to_vec(&request)?).await?;
     stream.write_all(b"\n").await?;
     stream.shutdown().await?;
@@ -46,41 +44,34 @@ pub async fn request(operation: &str, detail: String, cwd: PathBuf) -> Result<bo
     match response.trim() {
         "allow" => Ok(true),
         "deny" => Ok(false),
-        value => anyhow::bail!("invalid response from approval service: {value:?}"),
+        value => anyhow::bail!("invalid response from session: {value:?}"),
     }
 }
 
-pub async fn run_ui() -> Result<()> {
-    let path = socket_path()?;
-    let state_dir = path.parent().context("approval socket has no parent")?;
+pub async fn start() -> Result<()> {
+    let mut session = config::create_session(&std::env::current_dir()?).await?;
+    let path = config::socket_path(session.id)?;
+    let state_dir = path.parent().context("session socket has no parent")?;
     tokio::fs::create_dir_all(state_dir).await?;
     tokio::fs::set_permissions(state_dir, std::fs::Permissions::from_mode(0o700)).await?;
-
-    if UnixStream::connect(&path).await.is_ok() {
-        anyhow::bail!(
-            "another approval service is already listening at {}",
-            path.display()
-        );
-    }
-    match tokio::fs::remove_file(&path).await {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => return Err(error).context("failed to remove stale approval socket"),
-    }
+    remove_stale_socket(&path).await?;
 
     let listener = UnixListener::bind(&path)
         .with_context(|| format!("failed to listen at {}", path.display()))?;
     tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await?;
     eprintln!(
-        "Waiting for local-mcp approval requests at {}.\n\
-         Commands: /permissions yolo (allow all), /permissions ask (ask each time).\n\
+        "local-mcp session: {}\ncwd: {}\n\
+         Give this session ID to the agent and run: local-mcp mcp {}\n\
+         Commands: /permission ask|yolo|allow <directory>|revoke <directory>|list|status\n\
          Press Ctrl-C to stop.",
-        path.display()
+        session.id,
+        session.cwd.display(),
+        session.id
     );
+
     let mut input = BufReader::new(tokio::io::stdin()).lines();
     let mut pending = VecDeque::<(Request, UnixStream)>::new();
     let mut yolo = false;
-
     loop {
         tokio::select! {
             connection = listener.accept() => {
@@ -97,37 +88,110 @@ pub async fn run_ui() -> Result<()> {
                 }
             }
             line = input.next_line() => {
-                let Some(line) = line? else {
-                    anyhow::bail!("approval input closed");
-                };
-                match line.trim() {
-                    "/permissions yolo" | "/permission yolo" => {
-                        yolo = true;
-                        eprintln!("Permissions: yolo (all unsandboxed calls are allowed until this process exits)");
-                        while let Some((request, mut stream)) = pending.pop_front() {
-                            eprintln!("[yolo] allowing {}: {}", request.operation, request.detail);
-                            stream.write_all(b"allow\n").await?;
-                        }
-                    }
-                    "/permissions ask" | "/permission ask" => {
-                        yolo = false;
-                        eprintln!("Permissions: ask");
-                    }
-                    "y" | "Y" | "yes" | "YES" if !pending.is_empty() => {
-                        let (_, mut stream) = pending.pop_front().unwrap();
-                        stream.write_all(b"allow\n").await?;
-                        show_next(&pending)?;
-                    }
-                    _ if !pending.is_empty() => {
-                        let (_, mut stream) = pending.pop_front().unwrap();
-                        stream.write_all(b"deny\n").await?;
-                        show_next(&pending)?;
-                    }
-                    "" => {}
-                    command => eprintln!("Unknown command: {command}"),
-                }
+                let Some(line) = line? else { anyhow::bail!("session input closed") };
+                handle_input(line.trim(), &mut session, &mut yolo, &mut pending).await?;
             }
         }
+    }
+}
+
+async fn remove_stale_socket(path: &PathBuf) -> Result<()> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).context("failed to remove stale session socket"),
+    }
+}
+
+async fn handle_input(
+    input: &str,
+    session: &mut Session,
+    yolo: &mut bool,
+    pending: &mut VecDeque<(Request, UnixStream)>,
+) -> Result<()> {
+    match input {
+        "/permissions yolo" | "/permission yolo" => {
+            *yolo = true;
+            eprintln!("Permissions: yolo (all unsandboxed calls are allowed for this session)");
+            while let Some((request, mut stream)) = pending.pop_front() {
+                eprintln!("[yolo] allowing {}: {}", request.operation, request.detail);
+                stream.write_all(b"allow\n").await?;
+            }
+        }
+        "/permissions ask" | "/permission ask" => {
+            *yolo = false;
+            eprintln!("Permissions: ask");
+        }
+        "y" | "Y" | "yes" | "YES" if !pending.is_empty() => {
+            let (_, mut stream) = pending.pop_front().unwrap();
+            stream.write_all(b"allow\n").await?;
+            show_next(pending)?;
+        }
+        "n" | "N" | "no" | "NO" if !pending.is_empty() => {
+            let (_, mut stream) = pending.pop_front().unwrap();
+            stream.write_all(b"deny\n").await?;
+            show_next(pending)?;
+        }
+        "/permission list" | "/permissions list" => show_permissions(session),
+        "/permission status" | "/permissions status" => {
+            eprintln!("Permissions: {}", if *yolo { "yolo" } else { "ask" });
+            show_permissions(session);
+        }
+        command if permission_arg(command, "allow").is_some() => {
+            let directory = config::canonical_directory(
+                PathBuf::from(permission_arg(command, "allow").unwrap()).as_path(),
+            )?;
+            if !session.permitted_directories.contains(&directory) {
+                session.permitted_directories.push(directory.clone());
+                session.permitted_directories.sort();
+                config::save_session(session).await?;
+            }
+            eprintln!("Allowed sandbox root: {}", directory.display());
+        }
+        command if permission_arg(command, "revoke").is_some() => {
+            let directory = config::canonical_directory(
+                PathBuf::from(permission_arg(command, "revoke").unwrap()).as_path(),
+            )?;
+            if directory == session.cwd {
+                eprintln!("Cannot revoke the session cwd");
+            } else {
+                session
+                    .permitted_directories
+                    .retain(|item| item != &directory);
+                config::save_session(session).await?;
+                eprintln!("Revoked sandbox root: {}", directory.display());
+            }
+        }
+        "/permission" | "/permissions" | "/permission help" | "/permissions help" => {
+            eprintln!("/permission ask|yolo|allow <directory>|revoke <directory>|list|status");
+        }
+        "" => {}
+        command if !pending.is_empty() => {
+            let (_, mut stream) = pending.pop_front().unwrap();
+            stream.write_all(b"deny\n").await?;
+            eprintln!("Denied request (unrecognized response: {command})");
+            show_next(pending)?;
+        }
+        command => eprintln!("Unknown command: {command}"),
+    }
+    Ok(())
+}
+
+fn permission_arg<'a>(command: &'a str, action: &str) -> Option<&'a str> {
+    ["/permission", "/permissions"]
+        .into_iter()
+        .find_map(|prefix| {
+            command
+                .strip_prefix(&format!("{prefix} {action} "))
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
+}
+
+fn show_permissions(session: &Session) {
+    eprintln!("Sandbox roots:");
+    for path in &session.permitted_directories {
+        eprintln!("  {}", path.display());
     }
 }
 

--- a/src/approvals.rs
+++ b/src/approvals.rs
@@ -19,6 +19,18 @@ pub struct Request {
     pub cwd: PathBuf,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum Message {
+    Approval {
+        request: Request,
+    },
+    Activity {
+        title: String,
+        detail: Option<String>,
+    },
+}
+
 pub async fn request(
     session_id: Uuid,
     operation: &str,
@@ -35,7 +47,9 @@ pub async fn request(
     let mut stream = UnixStream::connect(&path)
         .await
         .with_context(|| format!("session {session_id} is not running; run `local-mcp start`"))?;
-    stream.write_all(&serde_json::to_vec(&request)?).await?;
+    stream
+        .write_all(&serde_json::to_vec(&Message::Approval { request })?)
+        .await?;
     stream.write_all(b"\n").await?;
     stream.shutdown().await?;
 
@@ -46,6 +60,28 @@ pub async fn request(
         "deny" => Ok(false),
         value => anyhow::bail!("invalid response from session: {value:?}"),
     }
+}
+
+/// Sends a one-way activity update to the `start` screen. Activity reporting is
+/// deliberately best-effort: an MCP operation must not fail just because its UI
+/// was closed between loading the session and completing the operation.
+pub async fn activity(session_id: Uuid, title: impl Into<String>, detail: Option<String>) {
+    let Ok(path) = config::socket_path(session_id) else {
+        return;
+    };
+    let Ok(mut stream) = UnixStream::connect(path).await else {
+        return;
+    };
+    let message = Message::Activity {
+        title: title.into(),
+        detail,
+    };
+    let Ok(bytes) = serde_json::to_vec(&message) else {
+        return;
+    };
+    let _ = stream.write_all(&bytes).await;
+    let _ = stream.write_all(b"\n").await;
+    let _ = stream.shutdown().await;
 }
 
 pub async fn start() -> Result<()> {
@@ -77,19 +113,32 @@ pub async fn start() -> Result<()> {
                 let (mut stream, _) = connection?;
                 let mut line = String::new();
                 BufReader::new(&mut stream).read_line(&mut line).await?;
-                let request: Request = serde_json::from_str(&line).context("invalid approval request")?;
-                if yolo {
-                    eprintln!("[yolo] allowing {}: {}", request.operation, request.detail);
-                    stream.write_all(b"allow\n").await?;
-                } else {
-                    show_request(&request)?;
-                    pending.push_back((request, stream));
+                let message: Message = serde_json::from_str(&line).context("invalid session message")?;
+                match message {
+                    Message::Activity { title, detail } => show_activity(&title, detail.as_deref()),
+                    Message::Approval { request } if yolo => {
+                        eprintln!("[yolo] allowing {}: {}", request.operation, request.detail);
+                        stream.write_all(b"allow\n").await?;
+                    }
+                    Message::Approval { request } => {
+                        show_request(&request)?;
+                        pending.push_back((request, stream));
+                    }
                 }
             }
             line = input.next_line() => {
                 let Some(line) = line? else { anyhow::bail!("session input closed") };
                 handle_input(line.trim(), &mut session, &mut yolo, &mut pending).await?;
             }
+        }
+    }
+}
+
+fn show_activity(title: &str, detail: Option<&str>) {
+    eprintln!("\n• {title}");
+    if let Some(detail) = detail.filter(|value| !value.is_empty()) {
+        for line in detail.lines() {
+            eprintln!("  {line}");
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 pub struct Config {
     #[serde(default)]
     pub permitted_directories: Vec<PathBuf>,
+    #[serde(default)]
+    pub default_cwd: Option<PathBuf>,
 }
 
 pub fn state_dir() -> Result<PathBuf> {
@@ -64,6 +66,10 @@ pub async fn revoke(path: &Path) -> Result<PathBuf> {
     Ok(path)
 }
 
-pub fn is_permitted(path: &Path, permitted: &[PathBuf]) -> bool {
-    permitted.iter().any(|root| path.starts_with(root))
+pub async fn set_default_cwd(path: &Path) -> Result<PathBuf> {
+    let path = canonical_directory(path)?;
+    let mut config = load().await?;
+    config.default_cwd = Some(path.clone());
+    save(&config).await?;
+    Ok(path)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,13 +2,14 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-#[derive(Default, Serialize, Deserialize)]
-pub struct Config {
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Session {
+    pub id: Uuid,
+    pub cwd: PathBuf,
     #[serde(default)]
     pub permitted_directories: Vec<PathBuf>,
-    #[serde(default)]
-    pub default_cwd: Option<PathBuf>,
 }
 
 pub fn state_dir() -> Result<PathBuf> {
@@ -18,58 +19,45 @@ pub fn state_dir() -> Result<PathBuf> {
         .context("could not determine a local state directory")
 }
 
-fn config_path() -> Result<PathBuf> {
-    Ok(state_dir()?.join("config.json"))
+pub fn session_path(id: Uuid) -> Result<PathBuf> {
+    Ok(state_dir()?.join("sessions").join(format!("{id}.json")))
 }
 
-pub async fn load() -> Result<Config> {
-    let path = config_path()?;
-    match tokio::fs::read(&path).await {
-        Ok(bytes) => serde_json::from_slice(&bytes).context("invalid local-mcp config"),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Config::default()),
-        Err(error) => Err(error).context("failed to read local-mcp config"),
-    }
+pub fn socket_path(id: Uuid) -> Result<PathBuf> {
+    Ok(state_dir()?.join("sessions").join(format!("{id}.sock")))
 }
 
-async fn save(config: &Config) -> Result<()> {
-    let path = config_path()?;
+pub async fn create_session(cwd: &Path) -> Result<Session> {
+    let cwd = canonical_directory(cwd)?;
+    let session = Session {
+        id: Uuid::new_v4(),
+        cwd: cwd.clone(),
+        permitted_directories: vec![cwd],
+    };
+    save_session(&session).await?;
+    Ok(session)
+}
+
+pub async fn load_session(id: Uuid) -> Result<Session> {
+    let path = session_path(id)?;
+    let bytes = tokio::fs::read(&path)
+        .await
+        .with_context(|| format!("session {id} was not found; run `local-mcp start` first"))?;
+    serde_json::from_slice(&bytes).context("invalid local-mcp session")
+}
+
+pub async fn save_session(session: &Session) -> Result<()> {
+    let path = session_path(session.id)?;
     tokio::fs::create_dir_all(path.parent().unwrap()).await?;
     let temporary = path.with_extension(format!("json.{}.tmp", std::process::id()));
-    tokio::fs::write(&temporary, serde_json::to_vec_pretty(config)?).await?;
+    tokio::fs::write(&temporary, serde_json::to_vec_pretty(session)?).await?;
     tokio::fs::rename(temporary, path).await?;
     Ok(())
 }
 
-fn canonical_directory(path: &Path) -> Result<PathBuf> {
+pub fn canonical_directory(path: &Path) -> Result<PathBuf> {
     let path = std::fs::canonicalize(path)
         .with_context(|| format!("cannot resolve {}", path.display()))?;
     anyhow::ensure!(path.is_dir(), "{} is not a directory", path.display());
-    Ok(path)
-}
-
-pub async fn permit(path: &Path) -> Result<PathBuf> {
-    let path = canonical_directory(path)?;
-    let mut config = load().await?;
-    if !config.permitted_directories.contains(&path) {
-        config.permitted_directories.push(path.clone());
-        config.permitted_directories.sort();
-        save(&config).await?;
-    }
-    Ok(path)
-}
-
-pub async fn revoke(path: &Path) -> Result<PathBuf> {
-    let path = canonical_directory(path)?;
-    let mut config = load().await?;
-    config.permitted_directories.retain(|item| item != &path);
-    save(&config).await?;
-    Ok(path)
-}
-
-pub async fn set_default_cwd(path: &Path) -> Result<PathBuf> {
-    let path = canonical_directory(path)?;
-    let mut config = load().await?;
-    config.default_cwd = Some(path.clone());
-    save(&config).await?;
     Ok(path)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ mod sandbox;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use uuid::Uuid;
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -18,8 +17,8 @@ struct Cli {
 enum Command {
     /// Start a session in the current directory and show its permission UI.
     Start,
-    /// Run the MCP server for a session over stdin/stdout.
-    Mcp { session_id: Uuid },
+    /// Run the session-independent MCP server over stdin/stdout.
+    Mcp,
 }
 
 #[tokio::main]
@@ -27,6 +26,6 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command.unwrap_or(Command::Start) {
         Command::Start => approvals::start().await,
-        Command::Mcp { session_id } => mcp::serve(session_id).await,
+        Command::Mcp => mcp::serve().await,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,10 +3,9 @@ mod config;
 mod mcp;
 mod sandbox;
 
-use std::path::PathBuf;
-
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use uuid::Uuid;
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -17,46 +16,17 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Run the MCP server over stdin/stdout (the default command).
-    Mcp,
-    /// Interactively approve or deny privileged tool calls.
-    Approvals,
-    /// Permanently allow sandboxed writes and commands rooted in a directory.
-    Permit { directory: PathBuf },
-    /// Remove a directory from the permanent allow-list.
-    Revoke { directory: PathBuf },
-    /// Show permanently permitted directories.
-    Permits,
-    /// Set the default working directory used by the MCP server.
-    SetCwd { directory: PathBuf },
+    /// Start a session in the current directory and show its permission UI.
+    Start,
+    /// Run the MCP server for a session over stdin/stdout.
+    Mcp { session_id: Uuid },
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
-    match cli.command.unwrap_or(Command::Mcp) {
-        Command::Mcp => mcp::serve().await,
-        Command::Approvals => approvals::run_ui().await,
-        Command::Permit { directory } => {
-            let path = config::permit(&directory).await?;
-            println!("permitted {}", path.display());
-            Ok(())
-        }
-        Command::Revoke { directory } => {
-            let path = config::revoke(&directory).await?;
-            println!("revoked {}", path.display());
-            Ok(())
-        }
-        Command::Permits => {
-            for path in config::load().await?.permitted_directories {
-                println!("{}", path.display());
-            }
-            Ok(())
-        }
-        Command::SetCwd { directory } => {
-            let path = config::set_default_cwd(&directory).await?;
-            println!("default cwd {}", path.display());
-            Ok(())
-        }
+    match cli.command.unwrap_or(Command::Start) {
+        Command::Start => approvals::start().await,
+        Command::Mcp { session_id } => mcp::serve(session_id).await,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ enum Command {
     Revoke { directory: PathBuf },
     /// Show permanently permitted directories.
     Permits,
+    /// Set the default working directory used by the MCP server.
+    SetCwd { directory: PathBuf },
 }
 
 #[tokio::main]
@@ -49,6 +51,11 @@ async fn main() -> Result<()> {
             for path in config::load().await?.permitted_directories {
                 println!("{}", path.display());
             }
+            Ok(())
+        }
+        Command::SetCwd { directory } => {
+            let path = config::set_default_cwd(&directory).await?;
+            println!("default cwd {}", path.display());
             Ok(())
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,12 +1,30 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde_json::{Value, json};
+use similar::{ChangeTag, TextDiff};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::{approvals, config, sandbox};
+
+const FOREGROUND_TIMEOUT: Duration = Duration::from_secs(30);
+
+struct Job {
+    session_id: Uuid,
+    command: String,
+    handle: JoinHandle<Result<String>>,
+}
+
+fn jobs() -> &'static Mutex<HashMap<Uuid, Job>> {
+    static JOBS: OnceLock<Mutex<HashMap<Uuid, Job>>> = OnceLock::new();
+    JOBS.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 pub async fn serve() -> Result<()> {
     let mut lines = BufReader::new(tokio::io::stdin()).lines();
@@ -72,7 +90,10 @@ fn tools() -> Value {
         {"name":"get_image","description":"Read a local image and return it as MCP image content. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string","description":"Path to a PNG, JPEG, GIF, WebP, BMP, TIFF, or AVIF image."}},"required":["session_id","path"],"additionalProperties":false}},
         {"name":"list_directory","description":"List entries in a local directory. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"}},"required":["session_id","path"]}},
         {"name":"write_file","description":"Write a UTF-8 file in the Codex sandbox. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"},"content":{"type":"string"}},"required":["session_id","path","content"]}},
-        {"name":"execute","description":"Execute argv without a shell in the Codex sandbox. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
+        {"name":"execute","description":"Execute argv without a shell in the Codex sandbox. Returns the normal result when it finishes within 30 seconds; otherwise returns a job_id for use with poll_job or stop_job. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
+        {"name":"start_command","description":"Start argv immediately as a background job in the Codex sandbox and return a job_id without waiting for completion. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
+        {"name":"poll_job","description":"Poll a background command returned by execute or start_command. Returns running while active, or the command result once completed.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"job_id":{"type":"string","format":"uuid"}},"required":["session_id","job_id"],"additionalProperties":false}},
+        {"name":"stop_job","description":"Stop a background command returned by execute or start_command.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"job_id":{"type":"string","format":"uuid"}},"required":["session_id","job_id"],"additionalProperties":false}},
         {"name":"without_sandbox","description":"Execute argv directly on the host with full user permissions and network access. Every call requires approval unless the session is in yolo mode.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}}
     ])
 }
@@ -89,20 +110,67 @@ async fn call_tool(params: &Value) -> Result<Value> {
     let session_id = required_session_id(&args)?;
     let session = config::load_session(session_id).await?;
     match name {
-        "session_info" => text_result(serde_json::to_string_pretty(&session)?),
-        "get_image" => get_image(&resolve_path(&session.cwd, required_path(&args, "path")?)).await,
-        "read_file" => text_result(
-            tokio::fs::read_to_string(resolve_path(&session.cwd, required_path(&args, "path")?))
-                .await?,
-        ),
-        "list_directory" => text_result(
-            list_directory(&resolve_path(&session.cwd, required_path(&args, "path")?)).await?,
-        ),
-        "write_file" => text_result(write_file(&args, &session.cwd).await?),
-        "execute" => text_result(execute(&args, &session).await?),
-        "without_sandbox" => text_result(without_sandbox(&args, &session).await?),
+        "session_info" => {
+            approvals::activity(session.id, "Read session info", None).await;
+            text_result(serde_json::to_string_pretty(&session)?)
+        }
+        "get_image" => {
+            let path = resolve_path(&session.cwd, required_path(&args, "path")?);
+            let result = get_image(&path).await;
+            report_result(
+                session.id,
+                format!("Read image {}", display_path(&path, &session.cwd)),
+                &result,
+            )
+            .await;
+            result
+        }
+        "read_file" => {
+            let path = resolve_path(&session.cwd, required_path(&args, "path")?);
+            let result = tokio::fs::read_to_string(&path)
+                .await
+                .context("failed to read file");
+            report_result(
+                session.id,
+                format!("Read {}", display_path(&path, &session.cwd)),
+                &result,
+            )
+            .await;
+            text_result(result?)
+        }
+        "list_directory" => {
+            let path = resolve_path(&session.cwd, required_path(&args, "path")?);
+            let result = list_directory(&path).await;
+            report_result(
+                session.id,
+                format!("Listed {}", display_path(&path, &session.cwd)),
+                &result,
+            )
+            .await;
+            text_result(result?)
+        }
+        "write_file" => write_file(&args, &session).await,
+        "execute" => execute(&args, &session).await,
+        "start_command" => start_command(&args, &session).await,
+        "poll_job" => poll_job(&args, &session).await,
+        "stop_job" => stop_job(&args, &session).await,
+        "without_sandbox" => without_sandbox(&args, &session).await,
         _ => anyhow::bail!("unknown tool: {name}"),
     }
+}
+
+async fn report_result<T>(session_id: Uuid, title: String, result: &Result<T>) {
+    let detail = result
+        .as_ref()
+        .err()
+        .map(|error| format!("└ Error: {error:#}"));
+    approvals::activity(session_id, title, detail).await;
+}
+
+fn display_path<'a>(path: &'a Path, session_cwd: &Path) -> std::borrow::Cow<'a, str> {
+    path.strip_prefix(session_cwd)
+        .unwrap_or(path)
+        .to_string_lossy()
 }
 
 fn text_result(text: String) -> Result<Value> {
@@ -204,8 +272,8 @@ async fn list_directory(path: &Path) -> Result<String> {
     Ok(names.join("\n"))
 }
 
-async fn write_file(args: &Value, session_cwd: &Path) -> Result<String> {
-    let absolute = resolve_path(session_cwd, required_path(args, "path")?);
+async fn write_file(args: &Value, session: &config::Session) -> Result<Value> {
+    let absolute = resolve_path(&session.cwd, required_path(args, "path")?);
     let parent = absolute.parent().context("file has no parent directory")?;
     let parent = std::fs::canonicalize(parent)
         .with_context(|| format!("parent does not exist: {}", parent.display()))?;
@@ -213,6 +281,9 @@ async fn write_file(args: &Value, session_cwd: &Path) -> Result<String> {
         .get("content")
         .and_then(Value::as_str)
         .context("missing content")?;
+    let previous = tokio::fs::read_to_string(&absolute)
+        .await
+        .unwrap_or_default();
     let command = vec![
         "sh".to_owned(),
         "-c".to_owned(),
@@ -227,32 +298,134 @@ async fn write_file(args: &Value, session_cwd: &Path) -> Result<String> {
         Some(content.as_bytes()),
     )
     .await?;
-    render_output(output)
+    let result = render_output(output);
+    let (added, removed, diff) = render_diff(&previous, content);
+    let title = format!(
+        "Edited {} (+{added} -{removed})",
+        display_path(&absolute, &session.cwd)
+    );
+    let detail = match &result {
+        Ok(_) => (!diff.is_empty()).then_some(diff),
+        Err(error) => Some(format!("└ Error: {error:#}")),
+    };
+    approvals::activity(session.id, title, detail).await;
+    text_result(result?)
 }
 
-async fn execute(args: &Value, session: &config::Session) -> Result<String> {
-    let command = args
-        .get("command")
-        .and_then(Value::as_array)
-        .context("missing command")?
-        .iter()
-        .map(|item| {
-            item.as_str()
-                .map(str::to_owned)
-                .context("command entries must be strings")
-        })
-        .collect::<Result<Vec<_>>>()?;
+async fn execute(args: &Value, session: &config::Session) -> Result<Value> {
+    let (rendered_command, mut handle) = spawn_sandboxed_command(args, session).await?;
+
+    match tokio::time::timeout(FOREGROUND_TIMEOUT, &mut handle).await {
+        Ok(joined) => text_result(joined.context("command task failed")??),
+        Err(_) => store_job(session, rendered_command, handle, "Backgrounded").await,
+    }
+}
+
+async fn start_command(args: &Value, session: &config::Session) -> Result<Value> {
+    let (rendered_command, handle) = spawn_sandboxed_command(args, session).await?;
+    store_job(session, rendered_command, handle, "Started").await
+}
+
+async fn spawn_sandboxed_command(
+    args: &Value,
+    session: &config::Session,
+) -> Result<(String, JoinHandle<Result<String>>)> {
+    let command = required_command(args)?;
     let cwd = cwd(args, &session.cwd)?;
     let mut roots = session.permitted_directories.clone();
     if !roots.iter().any(|root| cwd.starts_with(root)) {
         roots.push(cwd.clone());
     }
-    render_output(sandbox::run(&command, &cwd, &roots, None).await?)
+    let rendered_command = render_command(&command);
+    approvals::activity(session.id, format!("Running {rendered_command}"), None).await;
+    let session_id = session.id;
+    let task_command = rendered_command.clone();
+    let handle = tokio::spawn(async move {
+        let result = sandbox::run(&command, &cwd, &roots, None)
+            .await
+            .and_then(render_output);
+        report_command_finished(session_id, &task_command, &result).await;
+        result
+    });
+    Ok((rendered_command, handle))
 }
 
-async fn without_sandbox(args: &Value, session: &config::Session) -> Result<String> {
-    let command = args
-        .get("command")
+async fn store_job(
+    session: &config::Session,
+    rendered_command: String,
+    handle: JoinHandle<Result<String>>,
+    activity: &str,
+) -> Result<Value> {
+    let job_id = Uuid::new_v4();
+    jobs().lock().unwrap().insert(
+        job_id,
+        Job {
+            session_id: session.id,
+            command: rendered_command.clone(),
+            handle,
+        },
+    );
+    approvals::activity(
+        session.id,
+        format!("{activity} {rendered_command}"),
+        Some(format!("└ job {job_id}")),
+    )
+    .await;
+    text_result(json!({"status":"running","job_id":job_id}).to_string())
+}
+
+async fn poll_job(args: &Value, session: &config::Session) -> Result<Value> {
+    let job_id = required_job_id(args)?;
+    let finished = {
+        let jobs = jobs().lock().unwrap();
+        let job = jobs.get(&job_id).context("unknown job_id")?;
+        anyhow::ensure!(
+            job.session_id == session.id,
+            "job does not belong to this session"
+        );
+        job.handle.is_finished()
+    };
+    if !finished {
+        return text_result(json!({"status":"running","job_id":job_id}).to_string());
+    }
+
+    let job = jobs().lock().unwrap().remove(&job_id).unwrap();
+    let result = job.handle.await.context("background command task failed")?;
+    text_result(result?)
+}
+
+async fn stop_job(args: &Value, session: &config::Session) -> Result<Value> {
+    let job_id = required_job_id(args)?;
+    let job = {
+        let mut jobs = jobs().lock().unwrap();
+        let job = jobs.get(&job_id).context("unknown job_id")?;
+        anyhow::ensure!(
+            job.session_id == session.id,
+            "job does not belong to this session"
+        );
+        jobs.remove(&job_id).unwrap()
+    };
+    job.handle.abort();
+    let _ = job.handle.await;
+    approvals::activity(
+        session.id,
+        format!("Stopped {}", job.command),
+        Some(format!("└ job {job_id}")),
+    )
+    .await;
+    text_result(json!({"status":"stopped","job_id":job_id}).to_string())
+}
+
+fn required_job_id(args: &Value) -> Result<Uuid> {
+    let value = args
+        .get("job_id")
+        .and_then(Value::as_str)
+        .context("missing job_id")?;
+    Uuid::parse_str(value).context("invalid job_id")
+}
+
+fn required_command(args: &Value) -> Result<Vec<String>> {
+    args.get("command")
         .and_then(Value::as_array)
         .context("missing command")?
         .iter()
@@ -261,7 +434,11 @@ async fn without_sandbox(args: &Value, session: &config::Session) -> Result<Stri
                 .map(str::to_owned)
                 .context("command entries must be strings")
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect()
+}
+
+async fn without_sandbox(args: &Value, session: &config::Session) -> Result<Value> {
+    let command = required_command(args)?;
     let cwd = cwd(args, &session.cwd)?;
     if !approvals::request(
         session.id,
@@ -273,7 +450,94 @@ async fn without_sandbox(args: &Value, session: &config::Session) -> Result<Stri
     {
         anyhow::bail!("user denied without_sandbox")
     }
-    render_output(sandbox::run_unrestricted(&command, &cwd, None).await?)
+    run_and_report(session.id, command, cwd, true, &[]).await
+}
+
+async fn run_and_report(
+    session_id: Uuid,
+    command: Vec<String>,
+    cwd: PathBuf,
+    unrestricted: bool,
+    roots: &[PathBuf],
+) -> Result<Value> {
+    let rendered_command = render_command(&command);
+    approvals::activity(session_id, format!("Running {rendered_command}"), None).await;
+    let output = if unrestricted {
+        sandbox::run_unrestricted(&command, &cwd, None).await
+    } else {
+        sandbox::run(&command, &cwd, roots, None).await
+    };
+    let result = output.and_then(render_output);
+    report_command_finished(session_id, &rendered_command, &result).await;
+    text_result(result?)
+}
+
+fn render_command(command: &[String]) -> String {
+    command
+        .iter()
+        .map(|arg| shell_word(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+async fn report_command_finished(session_id: Uuid, command: &str, result: &Result<String>) {
+    let detail = match result {
+        Ok(text) => command_summary(text),
+        Err(error) => Some(format!("└ Error: {error:#}")),
+    };
+    approvals::activity(session_id, format!("Ran {command}"), detail).await;
+}
+
+fn shell_word(value: &str) -> String {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || "-_./:=+".contains(c))
+    {
+        value.to_owned()
+    } else {
+        format!("{:?}", value)
+    }
+}
+
+fn command_summary(text: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(text).ok()?;
+    let stdout = value
+        .get("stdout")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim_end();
+    let stderr = value
+        .get("stderr")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim_end();
+    let output = if stdout.is_empty() { stderr } else { stdout };
+    if output.is_empty() {
+        None
+    } else {
+        Some(
+            output
+                .lines()
+                .map(|line| format!("└ {line}"))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    }
+}
+
+fn render_diff(old: &str, new: &str) -> (usize, usize, String) {
+    let diff = TextDiff::from_lines(old, new);
+    let mut added = 0;
+    let mut removed = 0;
+    for change in diff.iter_all_changes() {
+        match change.tag() {
+            ChangeTag::Insert => added += 1,
+            ChangeTag::Delete => removed += 1,
+            ChangeTag::Equal => {}
+        }
+    }
+    let rendered = diff.unified_diff().context_radius(3).to_string();
+    (added, removed, rendered.trim_end().to_owned())
 }
 
 fn render_output(output: sandbox::Output) -> Result<String> {
@@ -297,6 +561,22 @@ mod tests {
         assert_eq!(image_mime_type(b"GIF89a"), Some("image/gif"));
         assert_eq!(image_mime_type(b"RIFF\0\0\0\0WEBP"), Some("image/webp"));
         assert_eq!(image_mime_type(b"not an image"), None);
+    }
+
+    #[test]
+    fn renders_edit_counts_and_unified_diff() {
+        let (added, removed, diff) = render_diff("one\ntwo\n", "one\nchanged\nthree\n");
+
+        assert_eq!((added, removed), (2, 1));
+        assert!(diff.contains("-two"));
+        assert!(diff.contains("+changed"));
+        assert!(diff.contains("+three"));
+    }
+
+    #[test]
+    fn quotes_command_arguments_for_activity_display() {
+        assert_eq!(shell_word("README.md"), "README.md");
+        assert_eq!(shell_word("hello world"), "\"hello world\"");
     }
 
     #[tokio::test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -7,6 +7,10 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use crate::{approvals, config, sandbox};
 
 pub async fn serve() -> Result<()> {
+    if let Some(default_cwd) = config::load().await?.default_cwd {
+        std::env::set_current_dir(&default_cwd)
+            .with_context(|| format!("cannot use default cwd {}", default_cwd.display()))?;
+    }
     let mut lines = BufReader::new(tokio::io::stdin()).lines();
     let mut stdout = tokio::io::stdout();
     while let Some(line) = lines.next_line().await? {
@@ -66,9 +70,9 @@ fn tools() -> Value {
     json!([
         {"name":"read_file","description":"Read a UTF-8 file from the local machine.","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}},
         {"name":"list_directory","description":"List entries in a local directory.","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}},
-        {"name":"write_file","description":"Write a UTF-8 file. Requires approval unless its parent is permitted.","inputSchema":{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}},
-        {"name":"execute","description":"Execute argv without a shell in the Codex sandbox. Network is disabled. Requires approval unless cwd is permitted.","inputSchema":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["command"]}},
-        {"name":"network_request","description":"Perform an HTTP request with curl in the Codex sandbox. Always requires approval.","inputSchema":{"type":"object","properties":{"url":{"type":"string"},"method":{"type":"string","default":"GET"},"body":{"type":"string"},"cwd":{"type":"string"}},"required":["url"]}}
+        {"name":"write_file","description":"Write a UTF-8 file in the Codex sandbox. Sandboxed calls do not require approval.","inputSchema":{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}},
+        {"name":"execute","description":"Execute argv without a shell in the Codex sandbox. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["command"]}},
+        {"name":"without_sandbox","description":"Execute argv directly on the host with full user permissions and network access. Every call requires user approval unless approvals is in yolo mode.","inputSchema":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["command"]}}
     ])
 }
 
@@ -86,7 +90,7 @@ async fn call_tool(params: &Value) -> Result<Value> {
         "list_directory" => list_directory(&required_path(&args, "path")?).await?,
         "write_file" => write_file(&args).await?,
         "execute" => execute(&args).await?,
-        "network_request" => network_request(&args).await?,
+        "without_sandbox" => without_sandbox(&args).await?,
         _ => anyhow::bail!("unknown tool: {name}"),
     };
     Ok(json!({"content":[{"type":"text","text":result}]}))
@@ -133,12 +137,6 @@ async fn write_file(args: &Value) -> Result<String> {
     let parent = absolute.parent().context("file has no parent directory")?;
     let parent = std::fs::canonicalize(parent)
         .with_context(|| format!("parent does not exist: {}", parent.display()))?;
-    let config = config::load().await?;
-    if !config::is_permitted(&parent, &config.permitted_directories)
-        && !approvals::request("write_file", absolute.display().to_string(), parent.clone()).await?
-    {
-        anyhow::bail!("user denied write_file")
-    }
     let content = args
         .get("content")
         .and_then(Value::as_str)
@@ -154,7 +152,6 @@ async fn write_file(args: &Value) -> Result<String> {
         &command,
         &parent,
         &[parent.clone()],
-        false,
         Some(content.as_bytes()),
     )
     .await?;
@@ -175,43 +172,30 @@ async fn execute(args: &Value) -> Result<String> {
         .collect::<Result<Vec<_>>>()?;
     let cwd = cwd(args)?;
     let config = config::load().await?;
-    let permitted = config::is_permitted(&cwd, &config.permitted_directories);
-    if !permitted
-        && !approvals::request("execute", format!("argv: {command:?}"), cwd.clone()).await?
-    {
-        anyhow::bail!("user denied execute")
+    let mut roots = config.permitted_directories;
+    if !roots.iter().any(|root| cwd.starts_with(root)) {
+        roots.push(cwd.clone());
     }
-    let roots = if permitted {
-        config.permitted_directories
-    } else {
-        vec![cwd.clone()]
-    };
-    render_output(sandbox::run(&command, &cwd, &roots, false, None).await?)
+    render_output(sandbox::run(&command, &cwd, &roots, None).await?)
 }
 
-async fn network_request(args: &Value) -> Result<String> {
-    let url = args
-        .get("url")
-        .and_then(Value::as_str)
-        .context("missing url")?;
-    let method = args.get("method").and_then(Value::as_str).unwrap_or("GET");
+async fn without_sandbox(args: &Value) -> Result<String> {
+    let command = args
+        .get("command")
+        .and_then(Value::as_array)
+        .context("missing command")?
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .map(str::to_owned)
+                .context("command entries must be strings")
+        })
+        .collect::<Result<Vec<_>>>()?;
     let cwd = cwd(args)?;
-    if !approvals::request("network_request", format!("{method} {url}"), cwd.clone()).await? {
-        anyhow::bail!("user denied network_request")
+    if !approvals::request("without_sandbox", format!("argv: {command:?}"), cwd.clone()).await? {
+        anyhow::bail!("user denied without_sandbox")
     }
-    let mut command = vec![
-        "curl".to_owned(),
-        "--fail-with-body".to_owned(),
-        "--silent".to_owned(),
-        "--show-error".to_owned(),
-        "--request".to_owned(),
-        method.to_owned(),
-        url.to_owned(),
-    ];
-    if let Some(body) = args.get("body").and_then(Value::as_str) {
-        command.extend(["--data-binary".to_owned(), body.to_owned()]);
-    }
-    render_output(sandbox::run(&command, &cwd, &[], true, None).await?)
+    render_output(sandbox::run_unrestricted(&command, &cwd, None).await?)
 }
 
 fn render_output(output: sandbox::Output) -> Result<String> {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -8,10 +8,7 @@ use uuid::Uuid;
 
 use crate::{approvals, config, sandbox};
 
-pub async fn serve(session_id: Uuid) -> Result<()> {
-    let session = config::load_session(session_id).await?;
-    std::env::set_current_dir(&session.cwd)
-        .with_context(|| format!("cannot use session cwd {}", session.cwd.display()))?;
+pub async fn serve() -> Result<()> {
     let mut lines = BufReader::new(tokio::io::stdin()).lines();
     let mut stdout = tokio::io::stdout();
     while let Some(line) = lines.next_line().await? {
@@ -29,7 +26,7 @@ pub async fn serve(session_id: Uuid) -> Result<()> {
             continue;
         }
         let id = request.get("id").cloned().unwrap_or(Value::Null);
-        let response = match dispatch(&request, session_id).await {
+        let response = match dispatch(&request).await {
             Ok(result) => json!({"jsonrpc":"2.0","id":id,"result":result}),
             Err(error) => {
                 json!({"jsonrpc":"2.0","id":id,"error":{"code":-32000,"message":format!("{error:#}")}})
@@ -49,7 +46,7 @@ async fn write_message(stdout: &mut tokio::io::Stdout, message: &Value) -> Resul
     Ok(())
 }
 
-async fn dispatch(request: &Value, session_id: Uuid) -> Result<Value> {
+async fn dispatch(request: &Value) -> Result<Value> {
     match request
         .get("method")
         .and_then(Value::as_str)
@@ -59,28 +56,28 @@ async fn dispatch(request: &Value, session_id: Uuid) -> Result<Value> {
             "protocolVersion": "2025-06-18",
             "capabilities": {"tools": {"listChanged": false}},
             "serverInfo": {"name": "local-mcp", "version": env!("CARGO_PKG_VERSION")},
-            "instructions": format!("This local-mcp connection belongs to session {session_id}. Call session_info to inspect its working directory and sandbox roots.")
+            "instructions": "Every tool call requires the local-mcp session_id supplied by the user. Call session_info with that ID to inspect its working directory and sandbox roots."
         })),
         "ping" => Ok(json!({})),
         "tools/list" => Ok(json!({"tools": tools()})),
-        "tools/call" => call_tool(request.get("params").unwrap_or(&Value::Null), session_id).await,
+        "tools/call" => call_tool(request.get("params").unwrap_or(&Value::Null)).await,
         method => anyhow::bail!("method not found: {method}"),
     }
 }
 
 fn tools() -> Value {
     json!([
-        {"name":"session_info","description":"Show the current local-mcp session ID, working directory, and allowed sandbox roots.","inputSchema":{"type":"object","properties":{},"additionalProperties":false}},
-        {"name":"read_file","description":"Read a UTF-8 file from the local machine.","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}},
-        {"name":"get_image","description":"Read a local image and return it as MCP image content.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Path to a PNG, JPEG, GIF, WebP, BMP, TIFF, or AVIF image."}},"required":["path"],"additionalProperties":false}},
-        {"name":"list_directory","description":"List entries in a local directory.","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}},
-        {"name":"write_file","description":"Write a UTF-8 file in the Codex sandbox. Sandboxed calls do not require approval.","inputSchema":{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}},
-        {"name":"execute","description":"Execute argv without a shell in the Codex sandbox. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["command"]}},
-        {"name":"without_sandbox","description":"Execute argv directly on the host with full user permissions and network access. Every call requires user approval unless approvals is in yolo mode.","inputSchema":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["command"]}}
+        {"name":"session_info","description":"Show a local-mcp session's ID, working directory, and allowed sandbox roots.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"}},"required":["session_id"],"additionalProperties":false}},
+        {"name":"read_file","description":"Read a UTF-8 file from the local machine. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"}},"required":["session_id","path"]}},
+        {"name":"get_image","description":"Read a local image and return it as MCP image content. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string","description":"Path to a PNG, JPEG, GIF, WebP, BMP, TIFF, or AVIF image."}},"required":["session_id","path"],"additionalProperties":false}},
+        {"name":"list_directory","description":"List entries in a local directory. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"}},"required":["session_id","path"]}},
+        {"name":"write_file","description":"Write a UTF-8 file in the Codex sandbox. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"},"content":{"type":"string"}},"required":["session_id","path","content"]}},
+        {"name":"execute","description":"Execute argv without a shell in the Codex sandbox. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
+        {"name":"without_sandbox","description":"Execute argv directly on the host with full user permissions and network access. Every call requires approval unless the session is in yolo mode.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}}
     ])
 }
 
-async fn call_tool(params: &Value, session_id: Uuid) -> Result<Value> {
+async fn call_tool(params: &Value) -> Result<Value> {
     let name = params
         .get("name")
         .and_then(Value::as_str)
@@ -89,19 +86,21 @@ async fn call_tool(params: &Value, session_id: Uuid) -> Result<Value> {
         .get("arguments")
         .cloned()
         .unwrap_or_else(|| json!({}));
+    let session_id = required_session_id(&args)?;
+    let session = config::load_session(session_id).await?;
     match name {
-        "session_info" => text_result(serde_json::to_string_pretty(
-            &config::load_session(session_id).await?,
-        )?),
-        "get_image" => {
-            let session = config::load_session(session_id).await?;
-            get_image(&required_path(&args, "path")?, &session.cwd).await
-        }
-        "read_file" => text_result(tokio::fs::read_to_string(required_path(&args, "path")?).await?),
-        "list_directory" => text_result(list_directory(&required_path(&args, "path")?).await?),
-        "write_file" => text_result(write_file(&args).await?),
-        "execute" => text_result(execute(&args, session_id).await?),
-        "without_sandbox" => text_result(without_sandbox(&args, session_id).await?),
+        "session_info" => text_result(serde_json::to_string_pretty(&session)?),
+        "get_image" => get_image(&resolve_path(&session.cwd, required_path(&args, "path")?)).await,
+        "read_file" => text_result(
+            tokio::fs::read_to_string(resolve_path(&session.cwd, required_path(&args, "path")?))
+                .await?,
+        ),
+        "list_directory" => text_result(
+            list_directory(&resolve_path(&session.cwd, required_path(&args, "path")?)).await?,
+        ),
+        "write_file" => text_result(write_file(&args, &session.cwd).await?),
+        "execute" => text_result(execute(&args, &session).await?),
+        "without_sandbox" => text_result(without_sandbox(&args, &session).await?),
         _ => anyhow::bail!("unknown tool: {name}"),
     }
 }
@@ -110,12 +109,7 @@ fn text_result(text: String) -> Result<Value> {
     Ok(json!({"content":[{"type":"text","text":text}]}))
 }
 
-async fn get_image(path: &Path, session_cwd: &Path) -> Result<Value> {
-    let path = if path.is_absolute() {
-        path.to_owned()
-    } else {
-        session_cwd.join(path)
-    };
+async fn get_image(path: &Path) -> Result<Value> {
     let path = tokio::fs::canonicalize(&path)
         .await
         .with_context(|| format!("cannot resolve image {}", path.display()))?;
@@ -169,12 +163,29 @@ fn required_path(args: &Value, name: &str) -> Result<PathBuf> {
         .context(format!("missing {name}"))
 }
 
-fn cwd(args: &Value) -> Result<PathBuf> {
+fn required_session_id(args: &Value) -> Result<Uuid> {
+    let value = args
+        .get("session_id")
+        .and_then(Value::as_str)
+        .context("missing session_id; ask the user to run `local-mcp start` and provide its ID")?;
+    Uuid::parse_str(value).context("invalid session_id")
+}
+
+fn resolve_path(session_cwd: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        session_cwd.join(path)
+    }
+}
+
+fn cwd(args: &Value, session_cwd: &Path) -> Result<PathBuf> {
     let path = args
         .get("cwd")
         .and_then(Value::as_str)
         .map(PathBuf::from)
-        .unwrap_or(std::env::current_dir()?);
+        .map(|path| resolve_path(session_cwd, path))
+        .unwrap_or_else(|| session_cwd.to_owned());
     std::fs::canonicalize(&path).with_context(|| format!("cannot resolve cwd {}", path.display()))
 }
 
@@ -193,13 +204,8 @@ async fn list_directory(path: &Path) -> Result<String> {
     Ok(names.join("\n"))
 }
 
-async fn write_file(args: &Value) -> Result<String> {
-    let path = required_path(args, "path")?;
-    let absolute = if path.is_absolute() {
-        path
-    } else {
-        std::env::current_dir()?.join(path)
-    };
+async fn write_file(args: &Value, session_cwd: &Path) -> Result<String> {
+    let absolute = resolve_path(session_cwd, required_path(args, "path")?);
     let parent = absolute.parent().context("file has no parent directory")?;
     let parent = std::fs::canonicalize(parent)
         .with_context(|| format!("parent does not exist: {}", parent.display()))?;
@@ -224,7 +230,7 @@ async fn write_file(args: &Value) -> Result<String> {
     render_output(output)
 }
 
-async fn execute(args: &Value, session_id: Uuid) -> Result<String> {
+async fn execute(args: &Value, session: &config::Session) -> Result<String> {
     let command = args
         .get("command")
         .and_then(Value::as_array)
@@ -236,16 +242,15 @@ async fn execute(args: &Value, session_id: Uuid) -> Result<String> {
                 .context("command entries must be strings")
         })
         .collect::<Result<Vec<_>>>()?;
-    let cwd = cwd(args)?;
-    let session = config::load_session(session_id).await?;
-    let mut roots = session.permitted_directories;
+    let cwd = cwd(args, &session.cwd)?;
+    let mut roots = session.permitted_directories.clone();
     if !roots.iter().any(|root| cwd.starts_with(root)) {
         roots.push(cwd.clone());
     }
     render_output(sandbox::run(&command, &cwd, &roots, None).await?)
 }
 
-async fn without_sandbox(args: &Value, session_id: Uuid) -> Result<String> {
+async fn without_sandbox(args: &Value, session: &config::Session) -> Result<String> {
     let command = args
         .get("command")
         .and_then(Value::as_array)
@@ -257,9 +262,9 @@ async fn without_sandbox(args: &Value, session_id: Uuid) -> Result<String> {
                 .context("command entries must be strings")
         })
         .collect::<Result<Vec<_>>>()?;
-    let cwd = cwd(args)?;
+    let cwd = cwd(args, &session.cwd)?;
     if !approvals::request(
-        session_id,
+        session.id,
         "without_sandbox",
         format!("argv: {command:?}"),
         cwd.clone(),
@@ -300,7 +305,7 @@ mod tests {
         let bytes = b"\x89PNG\r\n\x1a\nexample";
         tokio::fs::write(&path, bytes).await.unwrap();
 
-        let result = get_image(&path, Path::new("/")).await.unwrap();
+        let result = get_image(&path).await.unwrap();
         tokio::fs::remove_file(path).await.unwrap();
 
         assert_eq!(result["content"][0]["type"], "image");
@@ -315,7 +320,9 @@ mod tests {
         let path = directory.join("image.gif");
         tokio::fs::write(&path, b"GIF89a").await.unwrap();
 
-        let result = get_image(Path::new("image.gif"), &directory).await.unwrap();
+        let result = get_image(&resolve_path(&directory, PathBuf::from("image.gif")))
+            .await
+            .unwrap();
         tokio::fs::remove_dir_all(directory).await.unwrap();
 
         assert_eq!(result["content"][0]["mimeType"], "image/gif");

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,16 +1,17 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use uuid::Uuid;
 
 use crate::{approvals, config, sandbox};
 
-pub async fn serve() -> Result<()> {
-    if let Some(default_cwd) = config::load().await?.default_cwd {
-        std::env::set_current_dir(&default_cwd)
-            .with_context(|| format!("cannot use default cwd {}", default_cwd.display()))?;
-    }
+pub async fn serve(session_id: Uuid) -> Result<()> {
+    let session = config::load_session(session_id).await?;
+    std::env::set_current_dir(&session.cwd)
+        .with_context(|| format!("cannot use session cwd {}", session.cwd.display()))?;
     let mut lines = BufReader::new(tokio::io::stdin()).lines();
     let mut stdout = tokio::io::stdout();
     while let Some(line) = lines.next_line().await? {
@@ -28,7 +29,7 @@ pub async fn serve() -> Result<()> {
             continue;
         }
         let id = request.get("id").cloned().unwrap_or(Value::Null);
-        let response = match dispatch(&request).await {
+        let response = match dispatch(&request, session_id).await {
             Ok(result) => json!({"jsonrpc":"2.0","id":id,"result":result}),
             Err(error) => {
                 json!({"jsonrpc":"2.0","id":id,"error":{"code":-32000,"message":format!("{error:#}")}})
@@ -48,7 +49,7 @@ async fn write_message(stdout: &mut tokio::io::Stdout, message: &Value) -> Resul
     Ok(())
 }
 
-async fn dispatch(request: &Value) -> Result<Value> {
+async fn dispatch(request: &Value, session_id: Uuid) -> Result<Value> {
     match request
         .get("method")
         .and_then(Value::as_str)
@@ -57,18 +58,21 @@ async fn dispatch(request: &Value) -> Result<Value> {
         "initialize" => Ok(json!({
             "protocolVersion": "2025-06-18",
             "capabilities": {"tools": {"listChanged": false}},
-            "serverInfo": {"name": "local-mcp", "version": env!("CARGO_PKG_VERSION")}
+            "serverInfo": {"name": "local-mcp", "version": env!("CARGO_PKG_VERSION")},
+            "instructions": format!("This local-mcp connection belongs to session {session_id}. Call session_info to inspect its working directory and sandbox roots.")
         })),
         "ping" => Ok(json!({})),
         "tools/list" => Ok(json!({"tools": tools()})),
-        "tools/call" => call_tool(request.get("params").unwrap_or(&Value::Null)).await,
+        "tools/call" => call_tool(request.get("params").unwrap_or(&Value::Null), session_id).await,
         method => anyhow::bail!("method not found: {method}"),
     }
 }
 
 fn tools() -> Value {
     json!([
+        {"name":"session_info","description":"Show the current local-mcp session ID, working directory, and allowed sandbox roots.","inputSchema":{"type":"object","properties":{},"additionalProperties":false}},
         {"name":"read_file","description":"Read a UTF-8 file from the local machine.","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}},
+        {"name":"get_image","description":"Read a local image and return it as MCP image content.","inputSchema":{"type":"object","properties":{"path":{"type":"string","description":"Path to a PNG, JPEG, GIF, WebP, BMP, TIFF, or AVIF image."}},"required":["path"],"additionalProperties":false}},
         {"name":"list_directory","description":"List entries in a local directory.","inputSchema":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}},
         {"name":"write_file","description":"Write a UTF-8 file in the Codex sandbox. Sandboxed calls do not require approval.","inputSchema":{"type":"object","properties":{"path":{"type":"string"},"content":{"type":"string"}},"required":["path","content"]}},
         {"name":"execute","description":"Execute argv without a shell in the Codex sandbox. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["command"]}},
@@ -76,7 +80,7 @@ fn tools() -> Value {
     ])
 }
 
-async fn call_tool(params: &Value) -> Result<Value> {
+async fn call_tool(params: &Value, session_id: Uuid) -> Result<Value> {
     let name = params
         .get("name")
         .and_then(Value::as_str)
@@ -85,15 +89,77 @@ async fn call_tool(params: &Value) -> Result<Value> {
         .get("arguments")
         .cloned()
         .unwrap_or_else(|| json!({}));
-    let result = match name {
-        "read_file" => tokio::fs::read_to_string(required_path(&args, "path")?).await?,
-        "list_directory" => list_directory(&required_path(&args, "path")?).await?,
-        "write_file" => write_file(&args).await?,
-        "execute" => execute(&args).await?,
-        "without_sandbox" => without_sandbox(&args).await?,
+    match name {
+        "session_info" => text_result(serde_json::to_string_pretty(
+            &config::load_session(session_id).await?,
+        )?),
+        "get_image" => {
+            let session = config::load_session(session_id).await?;
+            get_image(&required_path(&args, "path")?, &session.cwd).await
+        }
+        "read_file" => text_result(tokio::fs::read_to_string(required_path(&args, "path")?).await?),
+        "list_directory" => text_result(list_directory(&required_path(&args, "path")?).await?),
+        "write_file" => text_result(write_file(&args).await?),
+        "execute" => text_result(execute(&args, session_id).await?),
+        "without_sandbox" => text_result(without_sandbox(&args, session_id).await?),
         _ => anyhow::bail!("unknown tool: {name}"),
+    }
+}
+
+fn text_result(text: String) -> Result<Value> {
+    Ok(json!({"content":[{"type":"text","text":text}]}))
+}
+
+async fn get_image(path: &Path, session_cwd: &Path) -> Result<Value> {
+    let path = if path.is_absolute() {
+        path.to_owned()
+    } else {
+        session_cwd.join(path)
     };
-    Ok(json!({"content":[{"type":"text","text":result}]}))
+    let path = tokio::fs::canonicalize(&path)
+        .await
+        .with_context(|| format!("cannot resolve image {}", path.display()))?;
+    let metadata = tokio::fs::metadata(&path).await?;
+    anyhow::ensure!(
+        metadata.is_file(),
+        "image path is not a file: {}",
+        path.display()
+    );
+    let bytes = tokio::fs::read(&path)
+        .await
+        .with_context(|| format!("cannot read image {}", path.display()))?;
+    let mime_type = image_mime_type(&bytes)
+        .with_context(|| format!("unsupported image format: {}", path.display()))?;
+    Ok(json!({
+        "content": [{
+            "type": "image",
+            "data": STANDARD.encode(bytes),
+            "mimeType": mime_type
+        }]
+    }))
+}
+
+fn image_mime_type(bytes: &[u8]) -> Option<&'static str> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        Some("image/png")
+    } else if bytes.starts_with(b"\xff\xd8\xff") {
+        Some("image/jpeg")
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        Some("image/gif")
+    } else if bytes.len() >= 12 && &bytes[..4] == b"RIFF" && &bytes[8..12] == b"WEBP" {
+        Some("image/webp")
+    } else if bytes.starts_with(b"BM") {
+        Some("image/bmp")
+    } else if bytes.starts_with(b"II*\0") || bytes.starts_with(b"MM\0*") {
+        Some("image/tiff")
+    } else if bytes.len() >= 12
+        && &bytes[4..8] == b"ftyp"
+        && matches!(&bytes[8..12], b"avif" | b"avis")
+    {
+        Some("image/avif")
+    } else {
+        None
+    }
 }
 
 fn required_path(args: &Value, name: &str) -> Result<PathBuf> {
@@ -158,7 +224,7 @@ async fn write_file(args: &Value) -> Result<String> {
     render_output(output)
 }
 
-async fn execute(args: &Value) -> Result<String> {
+async fn execute(args: &Value, session_id: Uuid) -> Result<String> {
     let command = args
         .get("command")
         .and_then(Value::as_array)
@@ -171,15 +237,15 @@ async fn execute(args: &Value) -> Result<String> {
         })
         .collect::<Result<Vec<_>>>()?;
     let cwd = cwd(args)?;
-    let config = config::load().await?;
-    let mut roots = config.permitted_directories;
+    let session = config::load_session(session_id).await?;
+    let mut roots = session.permitted_directories;
     if !roots.iter().any(|root| cwd.starts_with(root)) {
         roots.push(cwd.clone());
     }
     render_output(sandbox::run(&command, &cwd, &roots, None).await?)
 }
 
-async fn without_sandbox(args: &Value) -> Result<String> {
+async fn without_sandbox(args: &Value, session_id: Uuid) -> Result<String> {
     let command = args
         .get("command")
         .and_then(Value::as_array)
@@ -192,7 +258,14 @@ async fn without_sandbox(args: &Value) -> Result<String> {
         })
         .collect::<Result<Vec<_>>>()?;
     let cwd = cwd(args)?;
-    if !approvals::request("without_sandbox", format!("argv: {command:?}"), cwd.clone()).await? {
+    if !approvals::request(
+        session_id,
+        "without_sandbox",
+        format!("argv: {command:?}"),
+        cwd.clone(),
+    )
+    .await?
+    {
         anyhow::bail!("user denied without_sandbox")
     }
     render_output(sandbox::run_unrestricted(&command, &cwd, None).await?)
@@ -205,5 +278,46 @@ fn render_output(output: sandbox::Output) -> Result<String> {
         Ok(text)
     } else {
         anyhow::bail!(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_supported_image_types() {
+        assert_eq!(image_mime_type(b"\x89PNG\r\n\x1a\n"), Some("image/png"));
+        assert_eq!(image_mime_type(b"\xff\xd8\xff\xe0"), Some("image/jpeg"));
+        assert_eq!(image_mime_type(b"GIF89a"), Some("image/gif"));
+        assert_eq!(image_mime_type(b"RIFF\0\0\0\0WEBP"), Some("image/webp"));
+        assert_eq!(image_mime_type(b"not an image"), None);
+    }
+
+    #[tokio::test]
+    async fn get_image_returns_mcp_image_content() {
+        let path = std::env::temp_dir().join(format!("local-mcp-{}.png", uuid::Uuid::new_v4()));
+        let bytes = b"\x89PNG\r\n\x1a\nexample";
+        tokio::fs::write(&path, bytes).await.unwrap();
+
+        let result = get_image(&path, Path::new("/")).await.unwrap();
+        tokio::fs::remove_file(path).await.unwrap();
+
+        assert_eq!(result["content"][0]["type"], "image");
+        assert_eq!(result["content"][0]["mimeType"], "image/png");
+        assert_eq!(result["content"][0]["data"], STANDARD.encode(bytes));
+    }
+
+    #[tokio::test]
+    async fn get_image_resolves_relative_paths_from_session_cwd() {
+        let directory = std::env::temp_dir().join(format!("local-mcp-{}", uuid::Uuid::new_v4()));
+        tokio::fs::create_dir(&directory).await.unwrap();
+        let path = directory.join("image.gif");
+        tokio::fs::write(&path, b"GIF89a").await.unwrap();
+
+        let result = get_image(Path::new("image.gif"), &directory).await.unwrap();
+        tokio::fs::remove_dir_all(directory).await.unwrap();
+
+        assert_eq!(result["content"][0]["mimeType"], "image/gif");
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -75,6 +75,7 @@ pub async fn run(
         { anyhow::bail!("sandboxed execution is currently implemented for Linux only") };
 
     process
+        .kill_on_drop(true)
         .current_dir(&cwd)
         .env_clear()
         .envs(safe_environment())
@@ -111,6 +112,7 @@ pub async fn run_unrestricted(
         .with_context(|| format!("cannot resolve cwd {}", cwd.display()))?;
     let mut process = Command::new(&command[0]);
     process
+        .kill_on_drop(true)
         .args(&command[1..])
         .current_dir(cwd)
         .stdin(if stdin.is_some() {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4,7 +4,7 @@ use std::process::Stdio;
 
 use anyhow::{Context, Result};
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::permissions::{FileSystemSandboxPolicy, NetworkSandboxPolicy};
+use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -28,7 +28,6 @@ pub async fn run(
     command: &[String],
     cwd: &Path,
     writable_roots: &[PathBuf],
-    network: bool,
     stdin: Option<&[u8]>,
 ) -> Result<Output> {
     anyhow::ensure!(!command.is_empty(), "command must not be empty");
@@ -38,20 +37,13 @@ pub async fn run(
         .iter()
         .map(|path| absolute(path))
         .collect::<Result<Vec<_>>>()?;
-    let network_policy = if network {
-        NetworkSandboxPolicy::Enabled
-    } else {
-        NetworkSandboxPolicy::Restricted
-    };
-    let permissions = if network {
-        PermissionProfile::from_runtime_permissions(
-            &FileSystemSandboxPolicy::default(),
-            network_policy,
-        )
-    } else {
-        PermissionProfile::workspace_write_with(&roots, network_policy, true, true)
-            .materialize_project_roots_with_workspace_roots(&[absolute(&cwd)?])
-    };
+    let permissions = PermissionProfile::workspace_write_with(
+        &roots,
+        NetworkSandboxPolicy::Restricted,
+        true,
+        true,
+    )
+    .materialize_project_roots_with_workspace_roots(&[absolute(&cwd)?]);
 
     #[cfg(target_os = "linux")]
     let mut process = {
@@ -62,7 +54,7 @@ pub async fn run(
                 &permissions,
                 &cwd,
                 false,
-                network,
+                false,
             );
         let executable = std::env::current_exe()?
             .parent()
@@ -96,6 +88,41 @@ pub async fn run(
     let mut child = process
         .spawn()
         .context("failed to start sandboxed command")?;
+    if let Some(bytes) = stdin
+        && let Some(mut child_stdin) = child.stdin.take()
+    {
+        child_stdin.write_all(bytes).await?;
+    }
+    let output = child.wait_with_output().await?;
+    Ok(Output {
+        status: output.status.code().unwrap_or(-1),
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+    })
+}
+
+pub async fn run_unrestricted(
+    command: &[String],
+    cwd: &Path,
+    stdin: Option<&[u8]>,
+) -> Result<Output> {
+    anyhow::ensure!(!command.is_empty(), "command must not be empty");
+    let cwd = std::fs::canonicalize(cwd)
+        .with_context(|| format!("cannot resolve cwd {}", cwd.display()))?;
+    let mut process = Command::new(&command[0]);
+    process
+        .args(&command[1..])
+        .current_dir(cwd)
+        .stdin(if stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = process
+        .spawn()
+        .context("failed to start unsandboxed command")?;
     if let Some(bytes) = stdin
         && let Some(mut child_stdin) = child.stdin.take()
     {


### PR DESCRIPTION
## What changed

- allow sandboxed file writes and command execution without approval
- add an always-approved `without_sandbox` gate backed by the approvals socket
- add ask/yolo permission modes to the approvals UI
- remove the dedicated network request tool
- add persistent default working-directory configuration with `set-cwd`

## Why

Sandboxed operations should run autonomously while operations that bypass the Codex sandbox need an explicit, visible permission boundary. A session-scoped yolo mode supports intentional unattended operation without persisting unsafe permissions.

## Validation

- `cargo test --all-targets`
- sandboxed execution writes inside cwd without approval
- sandboxed network access is denied
- unsandboxed execution is rejected without the approvals service
- yolo mode approves consecutive unsandboxed calls
- relative paths resolve from the configured default cwd
- Nix package build
