### PR TITLE
Add macOS sandbox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ image reads, directory listings, sandboxed file writes and commands, plus explic
 unsandboxed command execution. It intentionally does not provide web search or a
 dedicated network-request tool.
 
-Commands are isolated with OpenAI Codex's `codex-rs/sandboxing` and Linux sandbox
-helper. Network access is denied for ordinary commands.
+Commands are isolated with OpenAI Codex's `codex-rs/sandboxing`: Landlock and the
+Linux sandbox helper on Linux, and Seatbelt (`sandbox-exec`) on macOS. Network
+access is denied for ordinary commands.
 
 ## Usage
 
@@ -38,7 +39,8 @@ local-mcp start my-project
 /permission status
 ```
 
-With Nix, `bwrap`, `curl`, and `bash` are included in the runtime environment:
+With Nix, `curl` and `bash` are included in the runtime environment. Linux builds
+also include `bwrap`:
 
 ```sh
 nix run github:OWNER/local-mcp
@@ -73,6 +75,7 @@ to check for completion or `stop_job` to terminate them. Use `start_command`
 when a command should run in the background immediately without the 30-second
 foreground wait.
 
-The build produces `local-mcp` and its sibling `codex-linux-sandbox`; install or
-copy both into the same directory. On Linux, `bwrap` (bubblewrap) must be
-available in `PATH`. macOS/Windows support is not implemented yet.
+On Linux, the build produces `local-mcp` and its sibling `codex-linux-sandbox`;
+install or copy both into the same directory, and ensure `bwrap` (bubblewrap) is
+available in `PATH`. On macOS, only `local-mcp` is needed; sandboxed commands use
+the system `/usr/bin/sandbox-exec`. Windows support is not implemented yet.

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,8 @@
       supportedSystems = [
         "x86_64-linux"
         "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
       ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
     in
@@ -36,11 +38,13 @@
             postInstall = ''
               wrapProgram $out/bin/local-mcp \
                 --prefix PATH : ${
-                  pkgs.lib.makeBinPath [
-                    pkgs.bash
-                    pkgs.bubblewrap
-                    pkgs.curl
-                  ]
+                  pkgs.lib.makeBinPath (
+                    [
+                      pkgs.bash
+                      pkgs.curl
+                    ]
+                    ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.bubblewrap ]
+                  )
                 }
             '';
 
@@ -71,7 +75,6 @@
         {
           default = pkgs.mkShell {
             packages = with pkgs; [
-              bubblewrap
               cargo
               cmake
               curl
@@ -80,7 +83,7 @@
               pkg-config
               rustc
               rustfmt
-            ];
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.bubblewrap ];
           };
         }
       );

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -70,9 +70,30 @@ pub async fn run(
         process
     };
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "macos")]
+    let mut process = {
+        use codex_sandboxing::seatbelt::CreateSeatbeltCommandArgsParams;
+        use codex_sandboxing::seatbelt::MACOS_PATH_TO_SEATBELT_EXECUTABLE;
+        use codex_sandboxing::seatbelt::create_seatbelt_command_args;
+
+        let (file_system_policy, network_policy) = permissions.to_runtime_permissions();
+        let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+            command: command.to_vec(),
+            file_system_sandbox_policy: &file_system_policy,
+            network_sandbox_policy: network_policy,
+            sandbox_policy_cwd: &cwd,
+            enforce_managed_network: false,
+            network: None,
+            extra_allow_unix_sockets: &[],
+        });
+        let mut process = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE);
+        process.args(args);
+        process
+    };
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     let mut process =
-        { anyhow::bail!("sandboxed execution is currently implemented for Linux only") };
+        { anyhow::bail!("sandboxed execution is currently implemented for Linux and macOS only") };
 
     process
         .kill_on_drop(true)
@@ -147,4 +168,80 @@ fn safe_environment() -> HashMap<String, String> {
                 .map(|value| (name.to_owned(), value))
         })
         .collect()
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    fn test_directory() -> PathBuf {
+        std::env::temp_dir().join(format!("local-mcp-sandbox-test-{}", Uuid::new_v4()))
+    }
+
+    #[tokio::test]
+    async fn seatbelt_allows_workspace_writes_and_denies_other_writes() -> Result<()> {
+        // Nix's macOS build sandbox does not allow a nested Seatbelt profile.
+        if std::env::var_os("NIX_BUILD_TOP").is_some() {
+            return Ok(());
+        }
+        let root = test_directory();
+        let workspace = root.join("workspace");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&workspace)?;
+        std::fs::create_dir_all(&outside)?;
+
+        let allowed = run(
+            &["/usr/bin/touch".into(), "allowed".into()],
+            &workspace,
+            &[],
+            None,
+        )
+        .await?;
+        assert_eq!(allowed.status, 0, "{}", allowed.stderr);
+        assert!(workspace.join("allowed").is_file());
+
+        let denied_path = outside.join("denied");
+        let denied = run(
+            &[
+                "/usr/bin/touch".into(),
+                denied_path.to_string_lossy().into_owned(),
+            ],
+            &workspace,
+            &[],
+            None,
+        )
+        .await?;
+        assert_ne!(denied.status, 0);
+        assert!(!denied_path.exists());
+
+        std::fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn seatbelt_denies_network_access() -> Result<()> {
+        if std::env::var_os("NIX_BUILD_TOP").is_some() {
+            return Ok(());
+        }
+        let workspace = test_directory();
+        std::fs::create_dir_all(&workspace)?;
+        let output = run(
+            &[
+                "/usr/bin/curl".into(),
+                "--fail".into(),
+                "--max-time".into(),
+                "2".into(),
+                "https://example.com".into(),
+            ],
+            &workspace,
+            &[],
+            None,
+        )
+        .await?;
+        assert_ne!(output.status, 0);
+
+        std::fs::remove_dir_all(workspace)?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
## What changed

- run sandboxed commands through Codex's Seatbelt policy generator and macOS `/usr/bin/sandbox-exec`
- add macOS sandbox integration tests for workspace writes, denied external writes, and denied network access
- expose `aarch64-darwin` and `x86_64-darwin` Nix outputs without pulling Linux-only bubblewrap into Darwin builds
- document platform-specific runtime requirements

## Why

`local-mcp` previously stopped all sandboxed command execution on non-Linux hosts and its Nix flake only exposed Linux systems. This adds the Codex-native macOS sandbox path while preserving the existing permission profile and restricted network policy.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test --all-targets` (8 passed on macOS, including live Seatbelt tests)
- `nix flake check --no-build`
- `nix build .#packages.aarch64-darwin.default`
- `./result/bin/local-mcp --version`
