### PR TITLE
Fix Unix socket path length issue on macOS

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,7 +34,7 @@ pub fn socket_path(id: &str) -> Result<PathBuf> {
 /// Socket paths have a platform-specific length limit (104 bytes on macOS),
 /// so they cannot live below the regular state directory, which may include
 /// a long home-directory path. Session metadata remains in `state_dir()`.
-pub fn socket_dir() -> PathBuf {
+fn socket_dir() -> PathBuf {
     // `TMPDIR` on macOS can itself be long, so use the conventional short
     // system temporary directory rather than `std::env::temp_dir()`.
     let uid = unsafe { libc::geteuid() };

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,19 @@ pub fn session_path(id: &str) -> Result<PathBuf> {
 
 pub fn socket_path(id: &str) -> Result<PathBuf> {
     validate_session_id(id)?;
-    Ok(state_dir()?.join("sessions").join(format!("{id}.sock")))
+    Ok(socket_dir().join(format!("{id}.sock")))
+}
+
+/// Returns a short, per-user directory for Unix-domain session sockets.
+///
+/// Socket paths have a platform-specific length limit (104 bytes on macOS),
+/// so they cannot live below the regular state directory, which may include
+/// a long home-directory path. Session metadata remains in `state_dir()`.
+pub fn socket_dir() -> PathBuf {
+    // `TMPDIR` on macOS can itself be long, so use the conventional short
+    // system temporary directory rather than `std::env::temp_dir()`.
+    let uid = unsafe { libc::geteuid() };
+    PathBuf::from("/tmp").join(format!("local-mcp-{uid}"))
 }
 
 pub async fn create_session(cwd: &Path, id: Option<&str>) -> Result<Session> {
@@ -91,5 +103,12 @@ mod tests {
         assert!(validate_session_id("../escape").is_err());
         assert!(validate_session_id("contains spaces").is_err());
         assert!(validate_session_id(&"x".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn puts_sockets_in_a_short_per_user_directory() {
+        let path = socket_path("7418eda5-fd07-4e00-ace5-c1ece2f68a02").unwrap();
+        assert_eq!(path.parent(), Some(socket_dir().as_path()));
+        assert!(path.as_os_str().len() < 104);
     }
 }


### PR DESCRIPTION
Macで実行したときにパスが長くなりすぎる問題を解消