### PR TITLE
Add Windows support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+jobs = 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup show
+      - name: Test
+        run: cargo test --locked --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,9 +367,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -422,9 +422,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -922,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "debugserver-types"
@@ -1063,13 +1063,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1115,9 +1115,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "ena"
@@ -1636,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2042,15 +2042,15 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "iri-string"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b1e6eaf9624f23be1969198c8f8e649ea8791e7ecfd6275ede2bdfeb88e168"
+checksum = "1663ee7d8cf2900cc1414b1e1eec9f348d6eaa3bcab07579f4726a4b8499f447"
 dependencies = [
  "memchr",
  "serde",
@@ -2175,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "landlock"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+checksum = "4cca98e95f35b29d469dade6724c6f96cec9236640f745a0e99b0334ec320ab1"
 dependencies = [
  "enumflags2",
  "libc",
@@ -2198,9 +2198,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -2227,6 +2227,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 name = "local-mcp"
 version = "0.1.0"
 dependencies = [
+ "allocative",
  "anyhow",
  "base64",
  "clap",
@@ -2237,6 +2238,9 @@ dependencies = [
  "dirs",
  "libc",
  "openssl",
+ "rama-error",
+ "rama-macros",
+ "rama-utils",
  "serde",
  "serde_json",
  "similar",
@@ -2784,9 +2788,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.220"
+version = "2.1.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de177021aa731f88221b3ae411cb89d70f66e51487c26ef9c9f65fc7250c22e8"
+checksum = "c0dedad316e05de220cbf3fd8bfb69f3df8755dde2d7d479211827b595168a93"
 dependencies = [
  "psl-types",
 ]
@@ -3401,9 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3429,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
@@ -3559,9 +3563,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -3728,7 +3732,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -4194,9 +4198,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4289,13 +4293,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4320,9 +4324,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4377,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,28 +2,36 @@
 name = "local-mcp"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.96"
 license = "Apache-2.0"
 description = "A sandboxed local-machine MCP server with out-of-band approvals"
 default-run = "local-mcp"
-
-[build]
-jobs = 4
 
 [dependencies]
 anyhow = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
-codex-linux-sandbox = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
 codex-protocol = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
-codex-sandboxing = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
 dirs = "6"
-openssl = { version = "0.10", features = ["vendored"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 similar = "2"
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "time"] }
 uuid = { version = "1", features = ["v4"] }
+# starlark 0.13 uses hashbrown 0.14. allocative 0.3.5+ moved its
+# hashbrown integration to a newer, type-incompatible release.
+allocative = "=0.3.4"
+rama-error = "=0.3.0-alpha.4"
+rama-macros = "=0.3.0-alpha.4"
+rama-utils = "=0.3.0-alpha.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+openssl = { version = "0.10", features = ["vendored"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+codex-sandboxing = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+codex-linux-sandbox = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ sessions.
 `get_image` returns PNG, JPEG, GIF, WebP, BMP, TIFF, and AVIF files as native MCP
 image content. Relative image paths are resolved from the session working directory.
 
-Each session uses its own permission-restricted local IPC endpoint (a Unix domain socket on Unix and a named pipe on Windows). Both the MCP
-server and the start UI block on I/O, so idle operation and pending approvals
-do not use polling timers.
+Each session uses its own local IPC endpoint: an explicitly permission-restricted
+Unix domain socket on Unix, or a named pipe using Windows' default security
+descriptor. Both the MCP server and the start UI block on I/O, so idle operation
+and pending approvals do not use polling timers.
 
 The `start` screen also receives live activity from MCP calls. It shows file and
 image reads, directory listings, file edits with unified diffs and line counts,
@@ -81,7 +82,12 @@ available in `PATH`. On macOS, only `local-mcp` is needed; sandboxed commands us
 the system `/usr/bin/sandbox-exec`. Windows uses named-pipe IPC and direct argv
 execution; it does not currently provide the filesystem/network sandbox enforced
 by Linux and macOS. Consequently, `execute` and `start_command` require approval
-on Windows unless the session is in yolo mode. Windows builds use the MSVC Rust
-target and require Visual Studio Build Tools with the "Desktop development with
-C++" workload. Build from a Developer PowerShell with
+on Windows unless the session is in yolo mode, while `write_file` writes directly
+to the requested host path. The Windows named pipe uses the
+[default security descriptor](https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipe-security-and-access-rights),
+which grants full control to LocalSystem, administrators, and the creator owner,
+and read access to Everyone and anonymous users; unlike Unix, `local-mcp` does not
+install an explicit per-user ACL. Windows builds use the MSVC Rust target and
+require Visual Studio Build Tools with the "Desktop development with C++"
+workload. Build from a Developer PowerShell with
 `cargo build --locked --release`.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ install or copy both into the same directory, and ensure `bwrap` (bubblewrap) is
 available in `PATH`. On macOS, only `local-mcp` is needed; sandboxed commands use
 the system `/usr/bin/sandbox-exec`. Windows uses named-pipe IPC and direct argv
 execution; it does not currently provide the filesystem/network sandbox enforced
-by Linux and macOS. Windows builds use the MSVC Rust target and require Visual
-Studio Build Tools with the "Desktop development with C++" workload. Build from
-a Developer PowerShell with `cargo build --locked --release`.
+by Linux and macOS. Consequently, `execute` and `start_command` require approval
+on Windows unless the session is in yolo mode. Windows builds use the MSVC Rust
+target and require Visual Studio Build Tools with the "Desktop development with
+C++" workload. Build from a Developer PowerShell with
+`cargo build --locked --release`.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ sessions.
 `get_image` returns PNG, JPEG, GIF, WebP, BMP, TIFF, and AVIF files as native MCP
 image content. Relative image paths are resolved from the session working directory.
 
-Each session uses its own permission-restricted Unix domain socket. Both the MCP
+Each session uses its own permission-restricted local IPC endpoint (a Unix domain socket on Unix and a named pipe on Windows). Both the MCP
 server and the start UI block on I/O, so idle operation and pending approvals
 do not use polling timers.
 
@@ -78,4 +78,8 @@ foreground wait.
 On Linux, the build produces `local-mcp` and its sibling `codex-linux-sandbox`;
 install or copy both into the same directory, and ensure `bwrap` (bubblewrap) is
 available in `PATH`. On macOS, only `local-mcp` is needed; sandboxed commands use
-the system `/usr/bin/sandbox-exec`. Windows support is not implemented yet.
+the system `/usr/bin/sandbox-exec`. Windows uses named-pipe IPC and direct argv
+execution; it does not currently provide the filesystem/network sandbox enforced
+by Linux and macOS. Windows builds use the MSVC Rust target and require Visual
+Studio Build Tools with the "Desktop development with C++" workload. Build from
+a Developer PowerShell with `cargo build --locked --release`.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96.0"
+profile = "minimal"

--- a/src/approvals.rs
+++ b/src/approvals.rs
@@ -52,6 +52,9 @@ impl SessionListener {
 fn new_pipe(path: &Path, first: bool) -> Result<NamedPipeServer> {
     let mut options = ServerOptions::new();
     options.first_pipe_instance(first);
+    // Tokio creates the pipe with a null SECURITY_ATTRIBUTES pointer, so the
+    // Windows default security descriptor applies. This is documented in the
+    // README rather than presented as equivalent to Unix's explicit 0600 mode.
     Ok(options.create(path)?)
 }
 

--- a/src/approvals.rs
+++ b/src/approvals.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+#[cfg(windows)]
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -11,6 +13,8 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
 #[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
+#[cfg(windows)]
+use tokio::time::{Instant, sleep};
 use uuid::Uuid;
 
 use crate::config::{self, Session};
@@ -35,40 +39,58 @@ impl SessionListener {
         }
         #[cfg(windows)]
         {
+            // Keep the connecting instance in listener state while awaiting so
+            // cancelling this future from `tokio::select!` cannot drop it.
+            self.server.connect().await?;
             let server = std::mem::replace(&mut self.server, new_pipe(&self.path, false)?);
-            server.connect().await?;
             return Ok(Box::new(server));
         }
     }
 }
 
 #[cfg(windows)]
-fn new_pipe(path: &PathBuf, first: bool) -> Result<NamedPipeServer> {
+fn new_pipe(path: &Path, first: bool) -> Result<NamedPipeServer> {
     let mut options = ServerOptions::new();
     options.first_pipe_instance(first);
     Ok(options.create(path)?)
 }
 
-async fn connect(path: &PathBuf) -> Result<SessionStream> {
+async fn connect(path: &Path) -> Result<SessionStream> {
     #[cfg(unix)]
     {
         Ok(Box::new(UnixStream::connect(path).await?))
     }
     #[cfg(windows)]
     {
-        Ok(Box::new(ClientOptions::new().open(path)?))
+        const ERROR_PIPE_BUSY: i32 = 231;
+        const RETRY_DELAY: Duration = Duration::from_millis(10);
+        const RETRY_TIMEOUT: Duration = Duration::from_secs(5);
+
+        let deadline = Instant::now() + RETRY_TIMEOUT;
+        loop {
+            match ClientOptions::new().open(path) {
+                Ok(client) => return Ok(Box::new(client)),
+                Err(error)
+                    if error.raw_os_error() == Some(ERROR_PIPE_BUSY)
+                        && Instant::now() < deadline =>
+                {
+                    sleep(RETRY_DELAY).await;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
     }
 }
 
 #[cfg(unix)]
-fn bind_listener(path: &PathBuf) -> Result<SessionListener> {
+fn bind_listener(path: &Path) -> Result<SessionListener> {
     Ok(SessionListener(UnixListener::bind(path)?))
 }
 
 #[cfg(windows)]
-fn bind_listener(path: &PathBuf) -> Result<SessionListener> {
+fn bind_listener(path: &Path) -> Result<SessionListener> {
     Ok(SessionListener {
-        path: path.clone(),
+        path: path.to_owned(),
         server: new_pipe(path, true)?,
     })
 }
@@ -333,4 +355,45 @@ fn show_next(pending: &VecDeque<(Request, SessionStream)>) -> Result<()> {
         show_request(request)?;
     }
     Ok(())
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use tokio::time::timeout;
+
+    fn pipe_path() -> PathBuf {
+        PathBuf::from(format!(r"\\.\pipe\local-mcp-test-{}", Uuid::new_v4()))
+    }
+
+    #[tokio::test]
+    async fn cancelling_accept_preserves_the_pipe_server() -> Result<()> {
+        let path = pipe_path();
+        let mut listener = bind_listener(&path)?;
+
+        assert!(
+            timeout(Duration::from_millis(10), listener.accept())
+                .await
+                .is_err()
+        );
+        let _client = ClientOptions::new().open(&path)?;
+        let _server = timeout(Duration::from_secs(1), listener.accept()).await??;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn connecting_retries_while_all_pipe_instances_are_busy() -> Result<()> {
+        let path = pipe_path();
+        let mut listener = bind_listener(&path)?;
+        let _first_client = ClientOptions::new().open(&path)?;
+
+        let client_path = path.clone();
+        let waiting_client = tokio::spawn(async move { connect(&client_path).await });
+        sleep(Duration::from_millis(50)).await;
+        let _first_server = listener.accept().await?;
+        let _second_client = timeout(Duration::from_secs(1), waiting_client).await???;
+
+        Ok(())
+    }
 }

--- a/src/approvals.rs
+++ b/src/approvals.rs
@@ -1,15 +1,77 @@
 use std::collections::VecDeque;
 use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+#[cfg(windows)]
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeServer, ServerOptions};
+#[cfg(unix)]
 use tokio::net::{UnixListener, UnixStream};
 use uuid::Uuid;
 
 use crate::config::{self, Session};
+
+trait SessionIo: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> SessionIo for T {}
+type SessionStream = Box<dyn SessionIo>;
+
+#[cfg(unix)]
+struct SessionListener(UnixListener);
+#[cfg(windows)]
+struct SessionListener {
+    path: PathBuf,
+    server: NamedPipeServer,
+}
+
+impl SessionListener {
+    async fn accept(&mut self) -> Result<SessionStream> {
+        #[cfg(unix)]
+        {
+            return Ok(Box::new(self.0.accept().await?.0));
+        }
+        #[cfg(windows)]
+        {
+            let server = std::mem::replace(&mut self.server, new_pipe(&self.path, false)?);
+            server.connect().await?;
+            return Ok(Box::new(server));
+        }
+    }
+}
+
+#[cfg(windows)]
+fn new_pipe(path: &PathBuf, first: bool) -> Result<NamedPipeServer> {
+    let mut options = ServerOptions::new();
+    options.first_pipe_instance(first);
+    Ok(options.create(path)?)
+}
+
+async fn connect(path: &PathBuf) -> Result<SessionStream> {
+    #[cfg(unix)]
+    {
+        Ok(Box::new(UnixStream::connect(path).await?))
+    }
+    #[cfg(windows)]
+    {
+        Ok(Box::new(ClientOptions::new().open(path)?))
+    }
+}
+
+#[cfg(unix)]
+fn bind_listener(path: &PathBuf) -> Result<SessionListener> {
+    Ok(SessionListener(UnixListener::bind(path)?))
+}
+
+#[cfg(windows)]
+fn bind_listener(path: &PathBuf) -> Result<SessionListener> {
+    Ok(SessionListener {
+        path: path.clone(),
+        server: new_pipe(path, true)?,
+    })
+}
 
 #[derive(Serialize, Deserialize)]
 pub struct Request {
@@ -44,7 +106,7 @@ pub async fn request(
         cwd,
     };
     let path = config::socket_path(session_id)?;
-    let mut stream = UnixStream::connect(&path)
+    let mut stream = connect(&path)
         .await
         .with_context(|| format!("session {session_id} is not running; run `local-mcp start`"))?;
     stream
@@ -69,7 +131,7 @@ pub async fn activity(session_id: &str, title: impl Into<String>, detail: Option
     let Ok(path) = config::socket_path(session_id) else {
         return;
     };
-    let Ok(mut stream) = UnixStream::connect(path).await else {
+    let Ok(mut stream) = connect(&path).await else {
         return;
     };
     let message = Message::Activity {
@@ -87,13 +149,17 @@ pub async fn activity(session_id: &str, title: impl Into<String>, detail: Option
 pub async fn start(session_id: Option<&str>) -> Result<()> {
     let mut session = config::create_session(&std::env::current_dir()?, session_id).await?;
     let path = config::socket_path(&session.id)?;
-    let state_dir = path.parent().context("session socket has no parent")?;
-    tokio::fs::create_dir_all(state_dir).await?;
-    tokio::fs::set_permissions(state_dir, std::fs::Permissions::from_mode(0o700)).await?;
+    #[cfg(unix)]
+    {
+        let state_dir = path.parent().context("session socket has no parent")?;
+        tokio::fs::create_dir_all(state_dir).await?;
+        tokio::fs::set_permissions(state_dir, std::fs::Permissions::from_mode(0o700)).await?;
+    }
     remove_stale_socket(&path).await?;
 
-    let listener = UnixListener::bind(&path)
-        .with_context(|| format!("failed to listen at {}", path.display()))?;
+    let mut listener =
+        bind_listener(&path).with_context(|| format!("failed to listen at {}", path.display()))?;
+    #[cfg(unix)]
     tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).await?;
     eprintln!(
         "local-mcp session: {}\ncwd: {}\n\
@@ -105,12 +171,12 @@ pub async fn start(session_id: Option<&str>) -> Result<()> {
     );
 
     let mut input = BufReader::new(tokio::io::stdin()).lines();
-    let mut pending = VecDeque::<(Request, UnixStream)>::new();
+    let mut pending = VecDeque::<(Request, SessionStream)>::new();
     let mut yolo = false;
     loop {
         tokio::select! {
             connection = listener.accept() => {
-                let (mut stream, _) = connection?;
+                let mut stream = connection?;
                 let mut line = String::new();
                 BufReader::new(&mut stream).read_line(&mut line).await?;
                 let message: Message = serde_json::from_str(&line).context("invalid session message")?;
@@ -143,6 +209,7 @@ fn show_activity(title: &str, detail: Option<&str>) {
     }
 }
 
+#[cfg(unix)]
 async fn remove_stale_socket(path: &PathBuf) -> Result<()> {
     match tokio::fs::remove_file(path).await {
         Ok(()) => Ok(()),
@@ -151,11 +218,16 @@ async fn remove_stale_socket(path: &PathBuf) -> Result<()> {
     }
 }
 
+#[cfg(windows)]
+async fn remove_stale_socket(_path: &PathBuf) -> Result<()> {
+    Ok(())
+}
+
 async fn handle_input(
     input: &str,
     session: &mut Session,
     yolo: &mut bool,
-    pending: &mut VecDeque<(Request, UnixStream)>,
+    pending: &mut VecDeque<(Request, SessionStream)>,
 ) -> Result<()> {
     match input {
         "/permissions yolo" | "/permission yolo" => {
@@ -256,7 +328,7 @@ fn show_request(request: &Request) -> Result<()> {
     Ok(())
 }
 
-fn show_next(pending: &VecDeque<(Request, UnixStream)>) -> Result<()> {
+fn show_next(pending: &VecDeque<(Request, SessionStream)>) -> Result<()> {
     if let Some((request, _)) = pending.front() {
         show_request(request)?;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,7 @@ pub fn session_path(id: &str) -> Result<PathBuf> {
 
 pub fn socket_path(id: &str) -> Result<PathBuf> {
     validate_session_id(id)?;
-    Ok(socket_dir().join(format!("{id}.sock")))
+    Ok(socket_path_for_id(id))
 }
 
 /// Returns a short, per-user directory for Unix-domain session sockets.
@@ -34,11 +34,22 @@ pub fn socket_path(id: &str) -> Result<PathBuf> {
 /// Socket paths have a platform-specific length limit (104 bytes on macOS),
 /// so they cannot live below the regular state directory, which may include
 /// a long home-directory path. Session metadata remains in `state_dir()`.
+#[cfg(unix)]
 fn socket_dir() -> PathBuf {
     // `TMPDIR` on macOS can itself be long, so use the conventional short
     // system temporary directory rather than `std::env::temp_dir()`.
     let uid = unsafe { libc::geteuid() };
     PathBuf::from("/tmp").join(format!("local-mcp-{uid}"))
+}
+
+#[cfg(unix)]
+fn socket_path_for_id(id: &str) -> PathBuf {
+    socket_dir().join(format!("{id}.sock"))
+}
+
+#[cfg(windows)]
+fn socket_path_for_id(id: &str) -> PathBuf {
+    PathBuf::from(format!(r"\\.\pipe\local-mcp-{id}"))
 }
 
 pub async fn create_session(cwd: &Path, id: Option<&str>) -> Result<Session> {
@@ -105,10 +116,21 @@ mod tests {
         assert!(validate_session_id(&"x".repeat(65)).is_err());
     }
 
+    #[cfg(unix)]
     #[test]
     fn puts_sockets_in_a_short_per_user_directory() {
         let path = socket_path("7418eda5-fd07-4e00-ace5-c1ece2f68a02").unwrap();
         assert_eq!(path.parent(), Some(socket_dir().as_path()));
         assert!(path.as_os_str().len() < 104);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn uses_a_named_pipe_for_session_ipc() {
+        let path = socket_path("7418eda5-fd07-4e00-ace5-c1ece2f68a02").unwrap();
+        assert_eq!(
+            path,
+            PathBuf::from(r"\\.\pipe\local-mcp-7418eda5-fd07-4e00-ace5-c1ece2f68a02")
+        );
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -294,20 +294,34 @@ async fn write_file(args: &Value, session: &config::Session) -> Result<Value> {
     let previous = tokio::fs::read_to_string(&absolute)
         .await
         .unwrap_or_default();
-    let command = vec![
-        "sh".to_owned(),
-        "-c".to_owned(),
-        "cat > \"$1\"".to_owned(),
-        "local-mcp-write".to_owned(),
-        absolute.display().to_string(),
-    ];
-    let output = sandbox::run(
-        &command,
-        &parent,
-        &[parent.clone()],
-        Some(content.as_bytes()),
-    )
-    .await?;
+    #[cfg(unix)]
+    let output = {
+        let command = vec![
+            "sh".to_owned(),
+            "-c".to_owned(),
+            "cat > \"$1\"".to_owned(),
+            "local-mcp-write".to_owned(),
+            absolute.display().to_string(),
+        ];
+        sandbox::run(
+            &command,
+            &parent,
+            std::slice::from_ref(&parent),
+            Some(content.as_bytes()),
+        )
+        .await?
+    };
+    #[cfg(windows)]
+    let output = {
+        // Windows has no application sandbox here, so avoid depending on a
+        // shell utility for the atomic file-edit operation.
+        tokio::fs::write(&absolute, content).await?;
+        sandbox::Output {
+            status: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+        }
+    };
     let result = render_output(output);
     let (added, removed, diff) = render_diff(&previous, content);
     let title = format!(

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -85,6 +85,10 @@ async fn dispatch(request: &Value) -> Result<Value> {
 
 fn tools() -> Value {
     #[cfg(not(windows))]
+    let write_file_description = "Write a UTF-8 file in the Codex sandbox. Relative paths use the session working directory.";
+    #[cfg(windows)]
+    let write_file_description = "Write a UTF-8 file directly on the Windows host without a Codex sandbox. Relative paths use the session working directory.";
+    #[cfg(not(windows))]
     let execute_description = "Execute argv without a shell in the Codex sandbox. Returns the normal result when it finishes within 30 seconds; otherwise returns a job_id for use with poll_job or stop_job. Network is disabled and approval is not required.";
     #[cfg(windows)]
     let execute_description = "Execute argv without a shell directly on the Windows host. Returns the normal result when it finishes within 30 seconds; otherwise returns a job_id for use with poll_job or stop_job. This has the user's filesystem and network access and requires approval unless the session is in yolo mode.";
@@ -98,7 +102,7 @@ fn tools() -> Value {
         {"name":"read_file","description":"Read a UTF-8 file from the local machine. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"}},"required":["session_id","path"]}},
         {"name":"get_image","description":"Read a local image and return it as MCP image content. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string","description":"Path to a PNG, JPEG, GIF, WebP, BMP, TIFF, or AVIF image."}},"required":["session_id","path"],"additionalProperties":false}},
         {"name":"list_directory","description":"List entries in a local directory. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"}},"required":["session_id","path"]}},
-        {"name":"write_file","description":"Write a UTF-8 file in the Codex sandbox. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"},"content":{"type":"string"}},"required":["session_id","path","content"]}},
+        {"name":"write_file","description":write_file_description,"inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"},"content":{"type":"string"}},"required":["session_id","path","content"]}},
         {"name":"execute","description":execute_description,"inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
         {"name":"start_command","description":start_command_description,"inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
         {"name":"poll_job","description":"Poll a background command returned by execute or start_command. Returns running while active, or the command result once completed.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"job_id":{"type":"string","format":"uuid"}},"required":["session_id","job_id"],"additionalProperties":false}},
@@ -323,7 +327,7 @@ async fn write_file(args: &Value, session: &config::Session) -> Result<Value> {
     #[cfg(windows)]
     let output = {
         // Windows has no application sandbox here, so avoid depending on a
-        // shell utility for the atomic file-edit operation.
+        // shell utility for the file-edit operation.
         tokio::fs::write(&absolute, content).await?;
         sandbox::Output {
             status: 0,
@@ -644,6 +648,17 @@ mod tests {
             assert!(description.contains("requires approval"));
             assert!(description.contains("filesystem and network access"));
         }
+
+        let write_file_description = tools
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|tool| tool["name"] == "write_file")
+            .unwrap()["description"]
+            .as_str()
+            .unwrap();
+        assert!(write_file_description.contains("Windows host"));
+        assert!(write_file_description.contains("without a Codex sandbox"));
     }
 
     #[tokio::test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -84,14 +84,23 @@ async fn dispatch(request: &Value) -> Result<Value> {
 }
 
 fn tools() -> Value {
+    #[cfg(not(windows))]
+    let execute_description = "Execute argv without a shell in the Codex sandbox. Returns the normal result when it finishes within 30 seconds; otherwise returns a job_id for use with poll_job or stop_job. Network is disabled and approval is not required.";
+    #[cfg(windows)]
+    let execute_description = "Execute argv without a shell directly on the Windows host. Returns the normal result when it finishes within 30 seconds; otherwise returns a job_id for use with poll_job or stop_job. This has the user's filesystem and network access and requires approval unless the session is in yolo mode.";
+    #[cfg(not(windows))]
+    let start_command_description = "Start argv immediately as a background job in the Codex sandbox and return a job_id without waiting for completion. Network is disabled and approval is not required.";
+    #[cfg(windows)]
+    let start_command_description = "Start argv immediately as a background job directly on the Windows host and return a job_id without waiting for completion. This has the user's filesystem and network access and requires approval unless the session is in yolo mode.";
+
     let mut tools = json!([
         {"name":"session_info","description":"Show a local-mcp session's ID, working directory, and allowed sandbox roots.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"}},"required":["session_id"],"additionalProperties":false}},
         {"name":"read_file","description":"Read a UTF-8 file from the local machine. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"}},"required":["session_id","path"]}},
         {"name":"get_image","description":"Read a local image and return it as MCP image content. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string","description":"Path to a PNG, JPEG, GIF, WebP, BMP, TIFF, or AVIF image."}},"required":["session_id","path"],"additionalProperties":false}},
         {"name":"list_directory","description":"List entries in a local directory. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"}},"required":["session_id","path"]}},
         {"name":"write_file","description":"Write a UTF-8 file in the Codex sandbox. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"},"content":{"type":"string"}},"required":["session_id","path","content"]}},
-        {"name":"execute","description":"Execute argv without a shell in the Codex sandbox. Returns the normal result when it finishes within 30 seconds; otherwise returns a job_id for use with poll_job or stop_job. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
-        {"name":"start_command","description":"Start argv immediately as a background job in the Codex sandbox and return a job_id without waiting for completion. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
+        {"name":"execute","description":execute_description,"inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
+        {"name":"start_command","description":start_command_description,"inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
         {"name":"poll_job","description":"Poll a background command returned by execute or start_command. Returns running while active, or the command result once completed.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"job_id":{"type":"string","format":"uuid"}},"required":["session_id","job_id"],"additionalProperties":false}},
         {"name":"stop_job","description":"Stop a background command returned by execute or start_command.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"job_id":{"type":"string","format":"uuid"}},"required":["session_id","job_id"],"additionalProperties":false}},
         {"name":"without_sandbox","description":"Execute argv directly on the host with full user permissions and network access. Every call requires approval unless the session is in yolo mode.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}}
@@ -337,7 +346,7 @@ async fn write_file(args: &Value, session: &config::Session) -> Result<Value> {
 }
 
 async fn execute(args: &Value, session: &config::Session) -> Result<Value> {
-    let (rendered_command, mut handle) = spawn_sandboxed_command(args, session).await?;
+    let (rendered_command, mut handle) = spawn_sandboxed_command("execute", args, session).await?;
 
     match tokio::time::timeout(FOREGROUND_TIMEOUT, &mut handle).await {
         Ok(joined) => text_result(joined.context("command task failed")??),
@@ -346,16 +355,31 @@ async fn execute(args: &Value, session: &config::Session) -> Result<Value> {
 }
 
 async fn start_command(args: &Value, session: &config::Session) -> Result<Value> {
-    let (rendered_command, handle) = spawn_sandboxed_command(args, session).await?;
+    let (rendered_command, handle) =
+        spawn_sandboxed_command("start_command", args, session).await?;
     store_job(session, rendered_command, handle, "Started").await
 }
 
 async fn spawn_sandboxed_command(
+    operation: &str,
     args: &Value,
     session: &config::Session,
 ) -> Result<(String, JoinHandle<Result<String>>)> {
     let command = required_command(args)?;
     let cwd = cwd(args, &session.cwd)?;
+    #[cfg(windows)]
+    if !approvals::request(
+        &session.id,
+        operation,
+        format!("argv: {command:?}"),
+        cwd.clone(),
+    )
+    .await?
+    {
+        anyhow::bail!("user denied {operation}")
+    }
+    #[cfg(not(windows))]
+    let _ = operation;
     let mut roots = session.permitted_directories.clone();
     if !roots.iter().any(|root| cwd.starts_with(root)) {
         roots.push(cwd.clone());
@@ -601,6 +625,25 @@ mod tests {
     fn quotes_command_arguments_for_activity_display() {
         assert_eq!(shell_word("README.md"), "README.md");
         assert_eq!(shell_word("hello world"), "\"hello world\"");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn describes_windows_command_execution_as_approved_host_access() {
+        let tools = tools();
+        for name in ["execute", "start_command"] {
+            let description = tools
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|tool| tool["name"] == name)
+                .unwrap()["description"]
+                .as_str()
+                .unwrap();
+            assert!(description.contains("Windows host"));
+            assert!(description.contains("requires approval"));
+            assert!(description.contains("filesystem and network access"));
+        }
     }
 
     #[tokio::test]

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -91,9 +91,19 @@ pub async fn run(
         process
     };
 
-    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    let mut process =
-        { anyhow::bail!("sandboxed execution is currently implemented for Linux and macOS only") };
+    #[cfg(windows)]
+    let mut process = {
+        // Windows has no equivalent of Landlock/Seatbelt in this application.
+        // Preserve argv execution and the restricted environment so the
+        // feature remains usable, while documenting that this is not a
+        // filesystem/network sandbox.
+        let mut process = Command::new(&command[0]);
+        process.args(&command[1..]);
+        process
+    };
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+    let mut process = { anyhow::bail!("sandboxed execution is unsupported on this platform") };
 
     process
         .kill_on_drop(true)
@@ -160,14 +170,23 @@ pub async fn run_unrestricted(
 }
 
 fn safe_environment() -> HashMap<String, String> {
-    ["PATH", "LANG", "LC_ALL", "TERM", "TMPDIR"]
-        .into_iter()
-        .filter_map(|name| {
-            std::env::var(name)
-                .ok()
-                .map(|value| (name.to_owned(), value))
-        })
-        .collect()
+    [
+        "PATH",
+        "LANG",
+        "LC_ALL",
+        "TERM",
+        "TMPDIR",
+        "TEMP",
+        "TMP",
+        "SystemRoot",
+    ]
+    .into_iter()
+    .filter_map(|name| {
+        std::env::var(name)
+            .ok()
+            .map(|value| (name.to_owned(), value))
+    })
+    .collect()
 }
 
 #[cfg(all(test, target_os = "macos"))]


### PR DESCRIPTION
## Summary

- use Windows named pipes for session approval and activity IPC
- compile platform-specific sandbox dependencies only where they are supported
- execute argv directly and perform native file writes on Windows
- pin the Rust toolchain and dependency versions needed by the current Codex revision
- run CI on both Ubuntu and Windows and document Windows build/runtime behavior

## Why

The application depended unconditionally on Unix sockets, Unix permissions, shell utilities, and Linux/macOS sandbox crates. Those assumptions prevented it from compiling and running on Windows.

## Impact

Windows users can build and run `local-mcp` with the MSVC Rust target. Linux continues to use Landlock/bubblewrap and macOS continues to use Seatbelt. Windows command execution is intentionally direct argv execution and does not provide the filesystem or network isolation available on Linux and macOS; this limitation is documented in the README.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets` (7 passed)
- `cargo clippy --locked --all-targets -- -D warnings`
- `git diff --check`
- Windows is covered by the new `windows-latest` GitHub Actions job. A local GNU cross-check reached native dependency compilation but could not continue because the host does not have `x86_64-w64-mingw32-gcc` installed.
