### PR TITLE
Add authenticated Streamable HTTP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1751,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2228,6 +2281,7 @@ name = "local-mcp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "base64",
  "clap",
  "codex-linux-sandbox",
@@ -2334,6 +2388,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "matchit"
@@ -2930,7 +2990,7 @@ dependencies = [
  "http-range-header",
  "httpdate",
  "iri-string",
- "matchit",
+ "matchit 0.9.2",
  "parking_lot",
  "percent-encoding",
  "pin-project-lite",
@@ -3693,6 +3753,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,6 +4468,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,12 +2289,16 @@ dependencies = [
  "codex-sandboxing",
  "codex-utils-absolute-path",
  "dirs",
+ "getrandom 0.3.4",
  "libc",
  "openssl",
+ "reqwest",
  "serde",
  "serde_json",
  "similar",
+ "subtle",
  "tokio",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,21 @@ jobs = 4
 anyhow = "1"
 axum = "0.8"
 base64 = "0.22"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 codex-linux-sandbox = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
 codex-protocol = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
 codex-sandboxing = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }
 dirs = "6"
+getrandom = "0.3"
 openssl = { version = "0.10", features = ["vendored"] }
+reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 similar = "2"
+subtle = "2"
 tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "time"] }
+url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ jobs = 4
 
 [dependencies]
 anyhow = "1"
+axum = "0.8"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 codex-linux-sandbox = { git = "https://github.com/openai/codex", rev = "20fedafff83f5c681fc62f73b0ca3227e42e3f8b" }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ local-mcp mcp-http
 # Choose another listen address when needed:
 local-mcp mcp-http --bind 127.0.0.1:8080
 
+# Require Authorization: Bearer <token> on every HTTP request. Using the
+# environment variable avoids exposing the token in the process argument list:
+LOCAL_MCP_BEARER_TOKEN='replace-with-a-secret' local-mcp mcp-http
+
+# Or generate a fresh, cryptographically secure 256-bit token at startup:
+local-mcp mcp-http --generate-bearer-token
+
+# Protect a publicly reachable server with OAuth 2.0. The authorization server
+# must expose an RFC 7662 introspection endpoint whose active responses include
+# this MCP server's canonical URI in the `aud` claim:
+LOCAL_MCP_OAUTH_ISSUER='https://auth.example.com/' \
+LOCAL_MCP_OAUTH_RESOURCE='https://mcp.example.com/mcp' \
+LOCAL_MCP_OAUTH_INTROSPECTION_ENDPOINT='https://auth.example.com/oauth/introspect' \
+LOCAL_MCP_OAUTH_CLIENT_ID='local-mcp' \
+LOCAL_MCP_OAUTH_CLIENT_SECRET='replace-with-a-secret' \
+local-mcp mcp-http --bind 0.0.0.0:3000
+
 # In another terminal, start a session in the project directory:
 cd ./some-project
 local-mcp start
@@ -66,9 +83,25 @@ from the prompt to confirm the working directory and sandbox roots. One MCP
 server process can therefore serve multiple independently configured sessions.
 `local-mcp mcp` uses stdin/stdout, while `local-mcp mcp-http` serves the stateless
 Streamable HTTP JSON response transport at `http://127.0.0.1:3000/mcp` by default.
-HTTP notifications receive `202 Accepted`. The HTTP server has no authentication,
-so it binds only to loopback by default; add authentication in a trusted reverse
-proxy before exposing it to other machines. Browser requests with an `Origin`
+HTTP notifications receive `202 Accepted`. The HTTP server binds only to loopback
+by default. Set `LOCAL_MCP_BEARER_TOKEN` or pass `--bearer-token` to require an
+`Authorization: Bearer <token>` header on every HTTP request. Authentication is
+disabled when neither is set. Alternatively, `--generate-bearer-token` creates a
+URL-safe 256-bit token from the operating system's secure random source and prints
+it once at startup.
+
+For OAuth 2.0, configure `LOCAL_MCP_OAUTH_ISSUER`,
+`LOCAL_MCP_OAUTH_RESOURCE`, and `LOCAL_MCP_OAUTH_INTROSPECTION_ENDPOINT` together.
+The optional client ID and secret authenticate `local-mcp` to the introspection
+endpoint with HTTP Basic authentication. OAuth mode publishes RFC 9728 Protected
+Resource Metadata at `/.well-known/oauth-protected-resource` and the MCP
+path-specific well-known URI, and advertises that metadata in `401 Unauthorized`
+responses. Each access token is checked through RFC 7662; only active tokens whose
+`aud` field contains the exact configured resource URI are accepted. The
+authorization server itself remains a separate service and must provide OAuth 2.1
+authorization and metadata endpoints to MCP clients.
+
+Browser requests with an `Origin`
 header are accepted only for `localhost`, `127.0.0.1`, and `::1` origins.
 `get_image` returns PNG, JPEG, GIF, WebP, BMP, TIFF, and AVIF files as native MCP
 image content. Relative image paths are resolved from the session working directory.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ access is denied for ordinary commands.
 ```sh
 cargo build --release
 
-# Run one persistent MCP server (for example through a tunnel):
+# Run one persistent MCP server over stdin/stdout (for example through a tunnel):
 local-mcp mcp
+
+# Or expose the same server over Streamable HTTP (POST /mcp):
+local-mcp mcp-http
+
+# Choose another listen address when needed:
+local-mcp mcp-http --bind 127.0.0.1:8080
 
 # In another terminal, start a session in the project directory:
 cd ./some-project
@@ -56,9 +62,14 @@ the approvals process before every call. `/permissions yolo` disables those
 prompts only for the lifetime of that session; `/permissions ask`
 turns prompts back on. The singular `/permission ...` spelling is also accepted.
 Every tool takes a `session_id`. The agent can call `session_info` with the ID
-from the prompt to confirm the working directory and sandbox roots. One
-`local-mcp mcp` process can therefore serve multiple independently configured
-sessions.
+from the prompt to confirm the working directory and sandbox roots. One MCP
+server process can therefore serve multiple independently configured sessions.
+`local-mcp mcp` uses stdin/stdout, while `local-mcp mcp-http` serves the stateless
+Streamable HTTP JSON response transport at `http://127.0.0.1:3000/mcp` by default.
+HTTP notifications receive `202 Accepted`. The HTTP server has no authentication,
+so it binds only to loopback by default; add authentication in a trusted reverse
+proxy before exposing it to other machines. Browser requests with an `Origin`
+header are accepted only for `localhost`, `127.0.0.1`, and `::1` origins.
 `get_image` returns PNG, JPEG, GIF, WebP, BMP, TIFF, and AVIF files as native MCP
 image content. Relative image paths are resolved from the session working directory.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod sandbox;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use std::net::SocketAddr;
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -22,6 +23,12 @@ enum Command {
     },
     /// Run the session-independent MCP server over stdin/stdout.
     Mcp,
+    /// Run the session-independent MCP server over Streamable HTTP.
+    McpHttp {
+        /// Address on which to listen. Defaults to loopback for safety.
+        #[arg(long, default_value = "127.0.0.1:3000")]
+        bind: SocketAddr,
+    },
 }
 
 #[tokio::main]
@@ -30,5 +37,6 @@ async fn main() -> Result<()> {
     match cli.command.unwrap_or(Command::Start { session_id: None }) {
         Command::Start { session_id } => approvals::start(session_id.as_deref()).await,
         Command::Mcp => mcp::serve().await,
+        Command::McpHttp { bind } => mcp::serve_http(bind).await,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,11 @@ mod config;
 mod mcp;
 mod sandbox;
 
-use anyhow::Result;
+use anyhow::{Result, ensure};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use clap::{Parser, Subcommand};
 use std::net::SocketAddr;
+use url::Url;
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -15,6 +17,7 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Command {
     /// Start a session in the current directory and show its permission UI.
     Start {
@@ -28,6 +31,41 @@ enum Command {
         /// Address on which to listen. Defaults to loopback for safety.
         #[arg(long, default_value = "127.0.0.1:3000")]
         bind: SocketAddr,
+        /// Require this bearer token for every HTTP request.
+        #[arg(long, env = "LOCAL_MCP_BEARER_TOKEN", hide_env_values = true)]
+        bearer_token: Option<String>,
+        /// Generate and require a new cryptographically secure bearer token.
+        #[arg(long, conflicts_with_all = ["bearer_token", "oauth_issuer"])]
+        generate_bearer_token: bool,
+        /// OAuth 2.0 authorization server issuer URL.
+        #[arg(
+            long,
+            env = "LOCAL_MCP_OAUTH_ISSUER",
+            requires_all = ["oauth_resource", "oauth_introspection_endpoint"],
+            conflicts_with_all = ["bearer_token", "generate_bearer_token"]
+        )]
+        oauth_issuer: Option<Url>,
+        /// Canonical public URI of this MCP resource (normally ending in /mcp).
+        #[arg(long, env = "LOCAL_MCP_OAUTH_RESOURCE", requires = "oauth_issuer")]
+        oauth_resource: Option<Url>,
+        /// RFC 7662 token introspection endpoint.
+        #[arg(
+            long,
+            env = "LOCAL_MCP_OAUTH_INTROSPECTION_ENDPOINT",
+            requires = "oauth_issuer"
+        )]
+        oauth_introspection_endpoint: Option<Url>,
+        /// Client ID used to authenticate to the introspection endpoint.
+        #[arg(long, env = "LOCAL_MCP_OAUTH_CLIENT_ID", requires = "oauth_issuer")]
+        oauth_client_id: Option<String>,
+        /// Client secret used to authenticate to the introspection endpoint.
+        #[arg(
+            long,
+            env = "LOCAL_MCP_OAUTH_CLIENT_SECRET",
+            hide_env_values = true,
+            requires = "oauth_client_id"
+        )]
+        oauth_client_secret: Option<String>,
     },
 }
 
@@ -37,6 +75,57 @@ async fn main() -> Result<()> {
     match cli.command.unwrap_or(Command::Start { session_id: None }) {
         Command::Start { session_id } => approvals::start(session_id.as_deref()).await,
         Command::Mcp => mcp::serve().await,
-        Command::McpHttp { bind } => mcp::serve_http(bind).await,
+        Command::McpHttp {
+            bind,
+            mut bearer_token,
+            generate_bearer_token,
+            oauth_issuer,
+            oauth_resource,
+            oauth_introspection_endpoint,
+            oauth_client_id,
+            oauth_client_secret,
+        } => {
+            if generate_bearer_token {
+                let token = generate_bearer_token_value()?;
+                eprintln!("Generated bearer token: {token}");
+                bearer_token = Some(token);
+            }
+            if let Some(token) = bearer_token.as_deref() {
+                ensure!(!token.is_empty(), "bearer token must not be empty");
+            }
+            let oauth = oauth_issuer.map(|issuer| mcp::OAuthConfig {
+                issuer,
+                resource: oauth_resource.expect("required by clap"),
+                introspection_endpoint: oauth_introspection_endpoint.expect("required by clap"),
+                client_id: oauth_client_id,
+                client_secret: oauth_client_secret,
+            });
+            mcp::serve_http(bind, bearer_token, oauth).await
+        }
+    }
+}
+
+fn generate_bearer_token_value() -> Result<String> {
+    let mut bytes = [0_u8; 32];
+    getrandom::fill(&mut bytes)?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generates_distinct_url_safe_256_bit_tokens() {
+        let first = generate_bearer_token_value().unwrap();
+        let second = generate_bearer_token_value().unwrap();
+
+        assert_eq!(first.len(), 43);
+        assert!(
+            first
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || b"-_".contains(&byte))
+        );
+        assert_ne!(first, second);
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,9 +1,15 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use axum::Router;
+use axum::body::Bytes;
+use axum::http::{HeaderMap, StatusCode, Uri, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde_json::{Value, json};
 use similar::{ChangeTag, TextDiff};
@@ -14,6 +20,7 @@ use uuid::Uuid;
 use crate::{approvals, config, sandbox};
 
 const FOREGROUND_TIMEOUT: Duration = Duration::from_secs(30);
+const PROTOCOL_VERSION: &str = "2025-06-18";
 
 struct Job {
     session_id: String,
@@ -40,19 +47,142 @@ pub async fn serve() -> Result<()> {
                 continue;
             }
         };
-        if request.get("id").is_none() {
-            continue;
+        if let Some(response) = handle_request(&request).await {
+            write_message(&mut stdout, &response).await?;
         }
-        let id = request.get("id").cloned().unwrap_or(Value::Null);
-        let response = match dispatch(&request).await {
-            Ok(result) => json!({"jsonrpc":"2.0","id":id,"result":result}),
-            Err(error) => {
-                json!({"jsonrpc":"2.0","id":id,"error":{"code":-32000,"message":format!("{error:#}")}})
-            }
-        };
-        write_message(&mut stdout, &response).await?;
     }
     Ok(())
+}
+
+pub async fn serve_http(bind: SocketAddr) -> Result<()> {
+    let listener = tokio::net::TcpListener::bind(bind)
+        .await
+        .with_context(|| format!("failed to bind HTTP server to {bind}"))?;
+    eprintln!("local-mcp HTTP server listening on http://{bind}/mcp");
+    axum::serve(
+        listener,
+        Router::new().route("/mcp", post(http_post).get(http_get).delete(http_get)),
+    )
+    .await
+    .context("HTTP server failed")
+}
+
+async fn http_get(headers: HeaderMap) -> Response {
+    if !has_valid_origin(&headers) {
+        return (StatusCode::FORBIDDEN, "Origin is not allowed").into_response();
+    }
+    StatusCode::METHOD_NOT_ALLOWED.into_response()
+}
+
+async fn http_post(headers: HeaderMap, body: Bytes) -> Response {
+    if !has_valid_origin(&headers) {
+        return (StatusCode::FORBIDDEN, "Origin is not allowed").into_response();
+    }
+    if !is_json_content_type(&headers) {
+        return (
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "Content-Type must be application/json",
+        )
+            .into_response();
+    }
+    if !accepts_json(&headers) {
+        return (
+            StatusCode::NOT_ACCEPTABLE,
+            "Accept must include application/json and text/event-stream",
+        )
+            .into_response();
+    }
+
+    let request: Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(error) => {
+            return json_response(json!({
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": {"code": -32700, "message": error.to_string()}
+            }));
+        }
+    };
+    if !has_supported_protocol_version(&headers, &request) {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("unsupported MCP-Protocol-Version; expected {PROTOCOL_VERSION}"),
+        )
+            .into_response();
+    }
+    match handle_request(&request).await {
+        Some(response) => json_response(response),
+        None => StatusCode::ACCEPTED.into_response(),
+    }
+}
+
+fn is_json_content_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case("application/json"))
+}
+
+fn has_valid_origin(headers: &HeaderMap) -> bool {
+    let Some(origin) = headers.get(header::ORIGIN) else {
+        return true;
+    };
+    origin
+        .to_str()
+        .ok()
+        .and_then(|value| value.parse::<Uri>().ok())
+        .and_then(|uri| uri.host().map(str::to_owned))
+        .is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || matches!(host.as_str(), "127.0.0.1" | "::1" | "[::1]")
+        })
+}
+
+fn has_supported_protocol_version(headers: &HeaderMap, request: &Value) -> bool {
+    if request.get("method").and_then(Value::as_str) == Some("initialize") {
+        return true;
+    }
+    headers
+        .get("mcp-protocol-version")
+        .map(|value| value.as_bytes() == PROTOCOL_VERSION.as_bytes())
+        .unwrap_or(true)
+}
+
+fn accepts_json(headers: &HeaderMap) -> bool {
+    let Some(value) = headers
+        .get(header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return false;
+    };
+    let accepts = |expected: &str| {
+        value.split(',').any(|item| {
+            item.trim()
+                .split(';')
+                .next()
+                .is_some_and(|mime| mime.eq_ignore_ascii_case(expected) || mime == "*/*")
+        })
+    };
+    accepts("application/json") && accepts("text/event-stream")
+}
+
+fn json_response(value: Value) -> Response {
+    (
+        [(header::CONTENT_TYPE, "application/json")],
+        value.to_string(),
+    )
+        .into_response()
+}
+
+async fn handle_request(request: &Value) -> Option<Value> {
+    let id = request.get("id")?.clone();
+    Some(match dispatch(request).await {
+        Ok(result) => json!({"jsonrpc":"2.0","id":id,"result":result}),
+        Err(error) => {
+            json!({"jsonrpc":"2.0","id":id,"error":{"code":-32000,"message":format!("{error:#}")}})
+        }
+    })
 }
 
 async fn write_message(stdout: &mut tokio::io::Stdout, message: &Value) -> Result<()> {
@@ -71,7 +201,7 @@ async fn dispatch(request: &Value) -> Result<Value> {
         .unwrap_or_default()
     {
         "initialize" => Ok(json!({
-            "protocolVersion": "2025-06-18",
+            "protocolVersion": PROTOCOL_VERSION,
             "capabilities": {"tools": {"listChanged": false}},
             "serverInfo": {"name": "local-mcp", "version": env!("CARGO_PKG_VERSION")},
             "instructions": "Every tool call requires the local-mcp session_id supplied by the user. Call session_info with that ID to inspect its working directory and sandbox roots."
@@ -564,6 +694,16 @@ fn render_output(output: sandbox::Output) -> Result<String> {
 mod tests {
     use super::*;
 
+    fn http_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
+        headers.insert(
+            header::ACCEPT,
+            "application/json, text/event-stream".parse().unwrap(),
+        );
+        headers
+    }
+
     #[test]
     fn detects_supported_image_types() {
         assert_eq!(image_mime_type(b"\x89PNG\r\n\x1a\n"), Some("image/png"));
@@ -616,5 +756,69 @@ mod tests {
         tokio::fs::remove_dir_all(directory).await.unwrap();
 
         assert_eq!(result["content"][0]["mimeType"], "image/gif");
+    }
+
+    #[tokio::test]
+    async fn http_returns_json_rpc_response() {
+        let response = http_post(
+            http_headers(),
+            Bytes::from_static(br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["id"], 1);
+        assert_eq!(body["result"]["serverInfo"]["name"], "local-mcp");
+    }
+
+    #[tokio::test]
+    async fn http_accepts_notifications_without_a_response_body() {
+        let response = http_post(
+            http_headers(),
+            Bytes::from_static(br#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn http_rejects_invalid_headers() {
+        let response = http_post(HeaderMap::new(), Bytes::from_static(b"{}")).await;
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+        let mut headers = http_headers();
+        headers.insert(header::ORIGIN, "https://example.com".parse().unwrap());
+        let response = http_post(headers, Bytes::from_static(b"{}")).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+        let mut headers = http_headers();
+        headers.insert("mcp-protocol-version", "unsupported".parse().unwrap());
+        let response = http_post(
+            headers,
+            Bytes::from_static(br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn http_get_reports_that_sse_is_not_available() {
+        let response = http_get(HeaderMap::new()).await;
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::ORIGIN, "https://example.com".parse().unwrap());
+        let response = http_get(headers).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -159,11 +159,7 @@ async fn http_post(State(state): State<HttpState>, headers: HeaderMap, body: Byt
         )
             .into_response();
     }
-    if !accepts_json(&headers) {
-        return (
-            StatusCode::NOT_ACCEPTABLE,
-            "Accept must include application/json and text/event-stream",
-        )
+            "Accept must include application/json",
             .into_response();
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,20 +1,23 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use axum::Router;
 use axum::body::Bytes;
 use axum::http::{HeaderMap, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
-use axum::routing::post;
+use axum::routing::{get, post};
+use axum::{Router, extract::State};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
+use reqwest::Client;
 use serde_json::{Value, json};
 use similar::{ChangeTag, TextDiff};
+use subtle::ConstantTimeEq;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
+use url::Url;
 use uuid::Uuid;
 
 use crate::{approvals, config, sandbox};
@@ -54,27 +57,98 @@ pub async fn serve() -> Result<()> {
     Ok(())
 }
 
-pub async fn serve_http(bind: SocketAddr) -> Result<()> {
+#[derive(Clone)]
+struct HttpState {
+    auth: HttpAuth,
+}
+
+#[derive(Clone)]
+enum HttpAuth {
+    Disabled,
+    Static(Arc<str>),
+    OAuth(Arc<OAuthVerifier>),
+}
+
+pub struct OAuthConfig {
+    pub issuer: Url,
+    pub resource: Url,
+    pub introspection_endpoint: Url,
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
+}
+
+struct OAuthVerifier {
+    config: OAuthConfig,
+    resource_metadata: Url,
+    client: Client,
+}
+
+pub async fn serve_http(
+    bind: SocketAddr,
+    bearer_token: Option<String>,
+    oauth: Option<OAuthConfig>,
+) -> Result<()> {
     let listener = tokio::net::TcpListener::bind(bind)
         .await
         .with_context(|| format!("failed to bind HTTP server to {bind}"))?;
-    eprintln!("local-mcp HTTP server listening on http://{bind}/mcp");
-    axum::serve(
-        listener,
-        Router::new().route("/mcp", post(http_post).get(http_get).delete(http_get)),
-    )
-    .await
-    .context("HTTP server failed")
+    let auth = match (bearer_token, oauth) {
+        (Some(token), None) => HttpAuth::Static(Arc::from(token)),
+        (None, Some(config)) => {
+            validate_oauth_config(&config)?;
+            let resource_metadata = protected_resource_metadata_url(&config.resource)?;
+            let client = Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .context("failed to build OAuth introspection client")?;
+            HttpAuth::OAuth(Arc::new(OAuthVerifier {
+                config,
+                resource_metadata,
+                client,
+            }))
+        }
+        (None, None) => HttpAuth::Disabled,
+        (Some(_), Some(_)) => unreachable!("authentication modes conflict in clap"),
+    };
+    let state = HttpState { auth };
+    let authentication = match &state.auth {
+        HttpAuth::Disabled => "authentication disabled",
+        HttpAuth::Static(_) => "static Bearer authentication required",
+        HttpAuth::OAuth(_) => "OAuth 2.0 authentication required",
+    };
+    eprintln!("local-mcp HTTP server listening on http://{bind}/mcp ({authentication})");
+    axum::serve(listener, http_router(state))
+        .await
+        .context("HTTP server failed")
 }
 
-async fn http_get(headers: HeaderMap) -> Response {
+fn http_router(state: HttpState) -> Router {
+    Router::new()
+        .route("/mcp", post(http_post).get(http_get).delete(http_get))
+        .route(
+            "/.well-known/oauth-protected-resource",
+            get(oauth_protected_resource),
+        )
+        .route(
+            "/.well-known/oauth-protected-resource/{*resource_path}",
+            get(oauth_protected_resource),
+        )
+        .with_state(state)
+}
+
+async fn http_get(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    if !authenticate(&headers, &state.auth).await {
+        return unauthorized_response(&state.auth);
+    }
     if !has_valid_origin(&headers) {
         return (StatusCode::FORBIDDEN, "Origin is not allowed").into_response();
     }
     StatusCode::METHOD_NOT_ALLOWED.into_response()
 }
 
-async fn http_post(headers: HeaderMap, body: Bytes) -> Response {
+async fn http_post(State(state): State<HttpState>, headers: HeaderMap, body: Bytes) -> Response {
+    if !authenticate(&headers, &state.auth).await {
+        return unauthorized_response(&state.auth);
+    }
     if !has_valid_origin(&headers) {
         return (StatusCode::FORBIDDEN, "Origin is not allowed").into_response();
     }
@@ -114,6 +188,154 @@ async fn http_post(headers: HeaderMap, body: Bytes) -> Response {
         Some(response) => json_response(response),
         None => StatusCode::ACCEPTED.into_response(),
     }
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let (scheme, token) = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split_once(' '))?;
+    scheme.eq_ignore_ascii_case("Bearer").then_some(token)
+}
+
+async fn authenticate(headers: &HeaderMap, auth: &HttpAuth) -> bool {
+    match auth {
+        HttpAuth::Disabled => true,
+        HttpAuth::Static(expected) => bearer_token(headers)
+            .is_some_and(|token| bool::from(token.as_bytes().ct_eq(expected.as_bytes()))),
+        HttpAuth::OAuth(verifier) => {
+            let Some(token) = bearer_token(headers) else {
+                return false;
+            };
+            match verifier.introspect(token).await {
+                Ok(valid) => valid,
+                Err(error) => {
+                    eprintln!("OAuth token introspection failed: {error:#}");
+                    false
+                }
+            }
+        }
+    }
+}
+
+impl OAuthVerifier {
+    async fn introspect(&self, token: &str) -> Result<bool> {
+        let mut request = self
+            .client
+            .post(self.config.introspection_endpoint.clone())
+            .form(&[("token", token), ("token_type_hint", "access_token")]);
+        if let Some(client_id) = self.config.client_id.as_deref() {
+            request = request.basic_auth(client_id, self.config.client_secret.as_deref());
+        }
+        let response = request
+            .send()
+            .await
+            .context("introspection request failed")?
+            .error_for_status()
+            .context("introspection endpoint returned an error")?;
+        let body: Value = response
+            .json()
+            .await
+            .context("invalid introspection response")?;
+        Ok(is_active_for_resource(
+            &body,
+            &self.config.issuer,
+            &self.config.resource,
+        ))
+    }
+}
+
+fn is_active_for_resource(body: &Value, issuer: &Url, resource: &Url) -> bool {
+    if body.get("active").and_then(Value::as_bool) != Some(true) {
+        return false;
+    }
+    if let Some(actual_issuer) = body.get("iss").and_then(Value::as_str)
+        && actual_issuer != issuer.as_str()
+    {
+        return false;
+    }
+    match body.get("aud") {
+        Some(Value::String(audience)) => audience == resource.as_str(),
+        Some(Value::Array(audiences)) => audiences
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|audience| audience == resource.as_str()),
+        _ => false,
+    }
+}
+
+fn validate_oauth_config(config: &OAuthConfig) -> Result<()> {
+    for (name, url) in [
+        ("OAuth issuer", &config.issuer),
+        ("OAuth resource", &config.resource),
+        (
+            "OAuth introspection endpoint",
+            &config.introspection_endpoint,
+        ),
+    ] {
+        ensure_http_url(name, url)?;
+    }
+    anyhow::ensure!(
+        config.client_secret.is_none() || config.client_id.is_some(),
+        "OAuth client secret requires a client ID"
+    );
+    Ok(())
+}
+
+fn ensure_http_url(name: &str, url: &Url) -> Result<()> {
+    anyhow::ensure!(
+        matches!(url.scheme(), "http" | "https") && url.host().is_some(),
+        "{name} must be an absolute HTTP(S) URL"
+    );
+    let is_loopback = url.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("localhost") || matches!(host, "127.0.0.1" | "::1" | "[::1]")
+    });
+    anyhow::ensure!(
+        url.scheme() == "https" || is_loopback,
+        "{name} must use HTTPS unless it has a loopback host"
+    );
+    Ok(())
+}
+
+fn protected_resource_metadata_url(resource: &Url) -> Result<Url> {
+    let mut metadata = resource.clone();
+    metadata.set_query(None);
+    metadata.set_fragment(None);
+    let resource_path = resource.path().trim_start_matches('/');
+    let path = if resource_path.is_empty() {
+        "/.well-known/oauth-protected-resource".to_owned()
+    } else {
+        format!("/.well-known/oauth-protected-resource/{resource_path}")
+    };
+    metadata.set_path(&path);
+    Ok(metadata)
+}
+
+async fn oauth_protected_resource(State(state): State<HttpState>) -> Response {
+    let HttpAuth::OAuth(verifier) = &state.auth else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    json_response(json!({
+        "resource": verifier.config.resource,
+        "authorization_servers": [verifier.config.issuer],
+        "bearer_methods_supported": ["header"]
+    }))
+}
+
+fn unauthorized_response(auth: &HttpAuth) -> Response {
+    let challenge = match auth {
+        HttpAuth::OAuth(verifier) => format!(
+            "Bearer resource_metadata=\"{}\"",
+            verifier.resource_metadata
+        ),
+        _ => "Bearer".to_owned(),
+    };
+    (
+        StatusCode::UNAUTHORIZED,
+        [(header::WWW_AUTHENTICATE, challenge)],
+        "Bearer token is missing or invalid",
+    )
+        .into_response()
 }
 
 fn is_json_content_type(headers: &HeaderMap) -> bool {
@@ -434,7 +656,7 @@ async fn write_file(args: &Value, session: &config::Session) -> Result<Value> {
     let output = sandbox::run(
         &command,
         &parent,
-        &[parent.clone()],
+        std::slice::from_ref(&parent),
         Some(content.as_bytes()),
     )
     .await?;
@@ -694,6 +916,31 @@ fn render_output(output: sandbox::Output) -> Result<String> {
 mod tests {
     use super::*;
 
+    fn http_state(bearer_token: Option<&str>) -> State<HttpState> {
+        State(HttpState {
+            auth: bearer_token
+                .map(|token| HttpAuth::Static(Arc::from(token)))
+                .unwrap_or(HttpAuth::Disabled),
+        })
+    }
+
+    fn oauth_state(introspection_endpoint: Url) -> State<HttpState> {
+        let config = OAuthConfig {
+            issuer: Url::parse("https://auth.example.com").unwrap(),
+            resource: Url::parse("https://mcp.example.com/mcp").unwrap(),
+            introspection_endpoint,
+            client_id: Some("local-mcp".to_owned()),
+            client_secret: Some("introspection-secret".to_owned()),
+        };
+        State(HttpState {
+            auth: HttpAuth::OAuth(Arc::new(OAuthVerifier {
+                resource_metadata: protected_resource_metadata_url(&config.resource).unwrap(),
+                config,
+                client: Client::new(),
+            })),
+        })
+    }
+
     fn http_headers() -> HeaderMap {
         let mut headers = HeaderMap::new();
         headers.insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
@@ -761,6 +1008,7 @@ mod tests {
     #[tokio::test]
     async fn http_returns_json_rpc_response() {
         let response = http_post(
+            http_state(None),
             http_headers(),
             Bytes::from_static(br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#),
         )
@@ -779,6 +1027,7 @@ mod tests {
     #[tokio::test]
     async fn http_accepts_notifications_without_a_response_body() {
         let response = http_post(
+            http_state(None),
             http_headers(),
             Bytes::from_static(br#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#),
         )
@@ -793,17 +1042,23 @@ mod tests {
 
     #[tokio::test]
     async fn http_rejects_invalid_headers() {
-        let response = http_post(HeaderMap::new(), Bytes::from_static(b"{}")).await;
+        let response = http_post(
+            http_state(None),
+            HeaderMap::new(),
+            Bytes::from_static(b"{}"),
+        )
+        .await;
         assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
 
         let mut headers = http_headers();
         headers.insert(header::ORIGIN, "https://example.com".parse().unwrap());
-        let response = http_post(headers, Bytes::from_static(b"{}")).await;
+        let response = http_post(http_state(None), headers, Bytes::from_static(b"{}")).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
         let mut headers = http_headers();
         headers.insert("mcp-protocol-version", "unsupported".parse().unwrap());
         let response = http_post(
+            http_state(None),
             headers,
             Bytes::from_static(br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#),
         )
@@ -813,12 +1068,120 @@ mod tests {
 
     #[tokio::test]
     async fn http_get_reports_that_sse_is_not_available() {
-        let response = http_get(HeaderMap::new()).await;
+        let response = http_get(http_state(None), HeaderMap::new()).await;
         assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
 
         let mut headers = HeaderMap::new();
         headers.insert(header::ORIGIN, "https://example.com".parse().unwrap());
-        let response = http_get(headers).await;
+        let response = http_get(http_state(None), headers).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn http_requires_configured_bearer_token() {
+        let response = http_post(
+            http_state(Some("secret-token")),
+            http_headers(),
+            Bytes::from_static(b"{}"),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.headers()[header::WWW_AUTHENTICATE], "Bearer");
+
+        let mut headers = http_headers();
+        headers.insert(header::AUTHORIZATION, "Bearer wrong-token".parse().unwrap());
+        let response = http_post(
+            http_state(Some("secret-token")),
+            headers,
+            Bytes::from_static(b"{}"),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let mut headers = http_headers();
+        headers.insert(
+            header::AUTHORIZATION,
+            "Bearer secret-token".parse().unwrap(),
+        );
+        let response = http_post(
+            http_state(Some("secret-token")),
+            headers,
+            Bytes::from_static(br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn http_authenticates_get_requests_too() {
+        let response = http_get(http_state(Some("secret-token")), HeaderMap::new()).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            "bearer secret-token".parse().unwrap(),
+        );
+        let response = http_get(http_state(Some("secret-token")), headers).await;
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn oauth_publishes_discovery_and_challenges() {
+        let state = oauth_state(Url::parse("https://auth.example.com/introspect").unwrap());
+        let _router = http_router(state.0.clone());
+
+        let metadata = oauth_protected_resource(state.clone()).await;
+        assert_eq!(metadata.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(metadata.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["resource"], "https://mcp.example.com/mcp");
+        assert_eq!(
+            body["authorization_servers"][0],
+            "https://auth.example.com/"
+        );
+
+        let response = http_post(state.clone(), http_headers(), Bytes::from_static(b"{}")).await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response.headers()[header::WWW_AUTHENTICATE],
+            "Bearer resource_metadata=\"https://mcp.example.com/.well-known/oauth-protected-resource/mcp\""
+        );
+    }
+
+    #[test]
+    fn oauth_accepts_only_active_audience_bound_tokens() {
+        let issuer = Url::parse("https://auth.example.com/").unwrap();
+        let resource = Url::parse("https://mcp.example.com/mcp").unwrap();
+        assert!(is_active_for_resource(
+            &json!({
+                "active": true,
+                "iss": issuer,
+                "aud": ["another-audience", resource]
+            }),
+            &issuer,
+            &resource
+        ));
+        assert!(!is_active_for_resource(
+            &json!({"active": false, "aud": resource}),
+            &issuer,
+            &resource
+        ));
+        assert!(!is_active_for_resource(
+            &json!({"active": true, "aud": "https://other.example.com/mcp"}),
+            &issuer,
+            &resource
+        ));
+    }
+
+    #[test]
+    fn oauth_metadata_url_follows_rfc_9728_path_insertion() {
+        let resource = Url::parse("https://mcp.example.com/public/mcp?ignored=yes").unwrap();
+        assert_eq!(
+            protected_resource_metadata_url(&resource).unwrap().as_str(),
+            "https://mcp.example.com/.well-known/oauth-protected-resource/public/mcp"
+        );
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -6,10 +6,10 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use axum::body::Bytes;
-use axum::http::{HeaderMap, StatusCode, Uri, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
-use axum::{Router, extract::State};
+use axum::{Router, extract::State, middleware};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use reqwest::Client;
 use serde_json::{Value, json};
@@ -123,7 +123,13 @@ pub async fn serve_http(
 
 fn http_router(state: HttpState) -> Router {
     Router::new()
-        .route("/mcp", post(http_post).get(http_get).delete(http_get))
+        .route(
+            "/mcp",
+            post(http_post)
+                .get(http_get)
+                .delete(http_get)
+                .options(http_options),
+        )
         .route(
             "/.well-known/oauth-protected-resource",
             get(oauth_protected_resource),
@@ -133,6 +139,42 @@ fn http_router(state: HttpState) -> Router {
             get(oauth_protected_resource),
         )
         .with_state(state)
+        .layer(middleware::from_fn(add_cors_headers))
+}
+
+async fn add_cors_headers(request: axum::extract::Request, next: middleware::Next) -> Response {
+    let origin = request
+        .headers()
+        .get(header::ORIGIN)
+        .filter(|_| has_valid_origin(request.headers()))
+        .cloned();
+    let mut response = next.run(request).await;
+    if let Some(origin) = origin {
+        let headers = response.headers_mut();
+        headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+        headers.insert(header::VARY, HeaderValue::from_static("Origin"));
+    }
+    response
+}
+
+async fn http_options(headers: HeaderMap) -> Response {
+    if !has_valid_origin(&headers) {
+        return (StatusCode::FORBIDDEN, "Origin is not allowed").into_response();
+    }
+    (
+        StatusCode::NO_CONTENT,
+        [
+            (
+                header::ACCESS_CONTROL_ALLOW_METHODS,
+                "POST, GET, DELETE, OPTIONS",
+            ),
+            (
+                header::ACCESS_CONTROL_ALLOW_HEADERS,
+                "Authorization, Content-Type, Accept, MCP-Protocol-Version",
+            ),
+        ],
+    )
+        .into_response()
 }
 
 async fn http_get(State(state): State<HttpState>, headers: HeaderMap) -> Response {
@@ -159,7 +201,11 @@ async fn http_post(State(state): State<HttpState>, headers: HeaderMap, body: Byt
         )
             .into_response();
     }
+    if !accepts_json(&headers) {
+        return (
+            StatusCode::NOT_ACCEPTABLE,
             "Accept must include application/json",
+        )
             .into_response();
     }
 
@@ -372,17 +418,14 @@ fn accepts_json(headers: &HeaderMap) -> bool {
         .get(header::ACCEPT)
         .and_then(|value| value.to_str().ok())
     else {
-        return false;
+        return true;
     };
-    let accepts = |expected: &str| {
-        value.split(',').any(|item| {
-            item.trim()
-                .split(';')
-                .next()
-                .is_some_and(|mime| mime.eq_ignore_ascii_case(expected) || mime == "*/*")
-        })
-    };
-    accepts("application/json") && accepts("text/event-stream")
+    value.split(',').any(|item| {
+        item.trim()
+            .split(';')
+            .next()
+            .is_some_and(|mime| mime.eq_ignore_ascii_case("application/json") || mime == "*/*")
+    })
 }
 
 fn json_response(value: Value) -> Response {
@@ -1132,6 +1175,57 @@ mod tests {
         )
         .await;
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn http_accepts_json_only_or_missing_accept() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
+        headers.insert(header::ACCEPT, "application/json".parse().unwrap());
+        let response = http_post(
+            http_state(None),
+            headers,
+            Bytes::from_static(br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
+        let response = http_post(
+            http_state(None),
+            headers,
+            Bytes::from_static(br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let mut headers = http_headers();
+        headers.insert(header::ACCEPT, "text/event-stream".parse().unwrap());
+        let response = http_post(
+            http_state(None),
+            headers,
+            Bytes::from_static(br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE);
+    }
+
+    #[tokio::test]
+    async fn http_handles_localhost_cors_preflight() {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::ORIGIN, "http://localhost:3000".parse().unwrap());
+        let response = http_options(headers).await;
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            response.headers()[header::ACCESS_CONTROL_ALLOW_METHODS],
+            "POST, GET, DELETE, OPTIONS"
+        );
+        assert_eq!(
+            response.headers()[header::ACCESS_CONTROL_ALLOW_HEADERS],
+            "Authorization, Content-Type, Accept, MCP-Protocol-Version"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add a `mcp-http` subcommand for stateless Streamable HTTP at `POST /mcp`
- add optional static Bearer authentication with secure token generation
- add MCP-compatible OAuth 2.0 resource-server support using RFC 9728 discovery and RFC 7662 token introspection
- validate active access tokens against the configured issuer and exact resource audience
- document HTTP, Bearer, and OAuth configuration

## Why

`local-mcp` previously supported only newline-delimited JSON-RPC over stdin/stdout. Remote HTTP exposure also needs an interoperable authorization mechanism because the server can access local files and execute commands.

## Impact

Run `local-mcp mcp-http` to listen on `http://127.0.0.1:3000/mcp`. Local deployments can configure a static token or generate one at startup. Public deployments can configure a separate OAuth 2.0/2.1 authorization server and its RFC 7662 introspection endpoint. OAuth mode publishes Protected Resource Metadata and includes its URL in `401 Unauthorized` challenges. Only active tokens whose `aud` contains the configured canonical MCP resource URI are accepted.

The endpoint remains stateless. JSON-RPC notifications return `202 Accepted`; GET returns `405 Method Not Allowed` because server-initiated SSE streams are not provided.

## Validation

- `cargo test --all-targets` (17 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo run --quiet -- mcp-http --help`
- `git diff --check`
