### PR TITLE
Add configurable CLI subagent providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 `local-mcp` exposes basic local-machine capabilities as MCP tools: file reads,
 image reads, directory listings, sandboxed file writes and commands, plus explicitly approved
-unsandboxed command execution. It intentionally does not provide web search or a
-dedicated network-request tool.
+unsandboxed command execution and read-only CLI subagents. It intentionally does not provide
+a built-in web search or dedicated network-request tool.
 
 Commands are isolated with OpenAI Codex's `codex-rs/sandboxing`: Landlock and the
 Linux sandbox helper on Linux, and Seatbelt (`sandbox-exec`) on macOS. Network
@@ -74,6 +74,47 @@ Longer commands continue in the background and return a `job_id`; use `poll_job`
 to check for completion or `stop_job` to terminate them. Use `start_command`
 when a command should run in the background immediately without the 30-second
 foreground wait.
+
+## CLI subagents
+
+Subagents follow Codex's thread-oriented multi-agent shape: `spawn_agent` starts
+a named task, `send_message` queues context, `followup_task` triggers another turn,
+`wait_agent` waits for completion, `list_agents` returns status and results, and
+`close_agent` releases a thread. Follow-up turns receive the recent transcript so
+they preserve the delegated task's context across separate CLI invocations.
+
+Providers are not enabled by the server. Configure the providers a session may use
+from the `local-mcp start` screen, similarly to permission management:
+
+```text
+/provider add fast opencode anthropic/claude-sonnet-4-5
+/provider add reviewer claude sonnet
+/provider add codex_readonly codex
+/provider default fast
+/provider list
+/provider remove reviewer
+```
+
+The first provider becomes the default automatically. A later `spawn_agent` can
+select one of these names with `agent_type`, or omit it to use the default. Provider
+configuration is saved with a stable session ID and restored on the next
+`local-mcp start <session-id>`. Each provider executable must be installed in the
+MCP server's `PATH` and authenticated using that CLI's normal setup.
+
+| Provider | Command | Safety mode | Optional `model` value |
+| --- | --- | --- | --- |
+| OpenCode | `opencode run` | pure plan agent with write/shell/MCP denied | `provider/model` |
+| Codex | `codex exec` | `--sandbox read-only` | Codex model name |
+| Claude Code | `claude --print` | safe plan mode with read-only built-ins | Claude model name or alias |
+| Gemini CLI | `gemini --prompt` | `--approval-mode plan` | Gemini model name |
+
+The task message is sent to the selected external provider. Spawning a thread runs
+on the host with network access and the CLI's existing credentials, so local-mcp
+requests explicit approval unless the session is in yolo mode. That permission is
+inherited by follow-up turns on the same thread, matching Codex's subagent model.
+Subagents are started in read-only or plan mode and return advice instead of
+modifying the workspace. Close agents when their work is no longer needed; each
+local-mcp session can keep up to four agent threads open concurrently.
 
 On Linux, the build produces `local-mcp` and its sibling `codex-linux-sandbox`;
 install or copy both into the same directory, and ensure `bwrap` (bubblewrap) is

--- a/src/approvals.rs
+++ b/src/approvals.rs
@@ -10,6 +10,7 @@ use tokio::net::{UnixListener, UnixStream};
 use uuid::Uuid;
 
 use crate::config::{self, Session};
+use crate::subagents;
 
 #[derive(Serialize, Deserialize)]
 pub struct Request {
@@ -98,7 +99,7 @@ pub async fn start(session_id: Option<&str>) -> Result<()> {
     eprintln!(
         "local-mcp session: {}\ncwd: {}\n\
          Give this session ID to the agent so it can include it in local-mcp tool calls.\n\
-         Commands: /permission ask|yolo|allow <directory>|revoke <directory>|list|status\n\
+         Commands: /permission help, /provider help\n\
          Press Ctrl-C to stop.",
         session.id,
         session.cwd.display()
@@ -128,7 +129,9 @@ pub async fn start(session_id: Option<&str>) -> Result<()> {
             }
             line = input.next_line() => {
                 let Some(line) = line? else { anyhow::bail!("session input closed") };
-                handle_input(line.trim(), &mut session, &mut yolo, &mut pending).await?;
+                if let Err(error) = handle_input(line.trim(), &mut session, &mut yolo, &mut pending).await {
+                    eprintln!("Command failed: {error:#}");
+                }
             }
         }
     }
@@ -210,6 +213,64 @@ async fn handle_input(
                 eprintln!("Revoked sandbox root: {}", directory.display());
             }
         }
+        command if provider_args(command, "add").is_some() => {
+            let values = provider_args(command, "add").unwrap();
+            anyhow::ensure!(
+                (2..=3).contains(&values.len()),
+                "usage: /provider add <name> <opencode|codex|claude|gemini> [model]"
+            );
+            let name = values[0];
+            let driver = values[1];
+            config::validate_provider_name(name)?;
+            anyhow::ensure!(
+                matches!(driver, "opencode" | "codex" | "claude" | "gemini"),
+                "unsupported provider driver: {driver}"
+            );
+            let provider = config::SubagentProvider {
+                driver: driver.to_owned(),
+                model: values.get(2).map(|value| (*value).to_owned()),
+            };
+            session.subagent_providers.insert(name.to_owned(), provider);
+            if session.default_subagent_provider.is_none() {
+                session.default_subagent_provider = Some(name.to_owned());
+            }
+            config::save_session(session).await?;
+            eprintln!("Configured provider: {name} ({driver})");
+        }
+        command if provider_args(command, "remove").is_some() => {
+            let values = provider_args(command, "remove").unwrap();
+            anyhow::ensure!(values.len() == 1, "usage: /provider remove <name>");
+            let name = values[0];
+            anyhow::ensure!(
+                session.subagent_providers.remove(name).is_some(),
+                "unknown provider: {name}"
+            );
+            if session.default_subagent_provider.as_deref() == Some(name) {
+                session.default_subagent_provider =
+                    session.subagent_providers.keys().next().cloned();
+            }
+            config::save_session(session).await?;
+            eprintln!("Removed provider: {name}");
+        }
+        command if provider_args(command, "default").is_some() => {
+            let values = provider_args(command, "default").unwrap();
+            anyhow::ensure!(values.len() == 1, "usage: /provider default <name>");
+            let name = values[0];
+            anyhow::ensure!(
+                session.subagent_providers.contains_key(name),
+                "unknown provider: {name}"
+            );
+            session.default_subagent_provider = Some(name.to_owned());
+            config::save_session(session).await?;
+            eprintln!("Default provider: {name}");
+        }
+        "/provider list" | "/providers list" | "/provider status" | "/providers status" => {
+            show_providers(session)
+        }
+        "/provider" | "/providers" | "/provider help" | "/providers help" => {
+            eprintln!("/provider add <name> <opencode|codex|claude|gemini> [model]");
+            eprintln!("/provider default <name> | remove <name> | list");
+        }
         "/permission" | "/permissions" | "/permission help" | "/permissions help" => {
             eprintln!("/permission ask|yolo|allow <directory>|revoke <directory>|list|status");
         }
@@ -236,10 +297,43 @@ fn permission_arg<'a>(command: &'a str, action: &str) -> Option<&'a str> {
         })
 }
 
+fn provider_args<'a>(command: &'a str, action: &str) -> Option<Vec<&'a str>> {
+    ["/provider", "/providers"].into_iter().find_map(|prefix| {
+        command
+            .strip_prefix(&format!("{prefix} {action} "))
+            .map(str::split_whitespace)
+            .map(Iterator::collect)
+    })
+}
+
 fn show_permissions(session: &Session) {
     eprintln!("Sandbox roots:");
     for path in &session.permitted_directories {
         eprintln!("  {}", path.display());
+    }
+}
+
+fn show_providers(session: &Session) {
+    eprintln!("Subagent providers:");
+    if session.subagent_providers.is_empty() {
+        eprintln!("  (none; use /provider add)");
+    }
+    for (name, provider) in &session.subagent_providers {
+        let marker = if session.default_subagent_provider.as_deref() == Some(name) {
+            " (default)"
+        } else {
+            ""
+        };
+        let model = provider.model.as_deref().unwrap_or("provider default");
+        let availability = if subagents::driver_available(&provider.driver) {
+            "installed"
+        } else {
+            "missing"
+        };
+        eprintln!(
+            "  {name}: {} / {model} [{availability}]{marker}",
+            provider.driver
+        );
     }
 }
 
@@ -261,4 +355,22 @@ fn show_next(pending: &VecDeque<(Request, UnixStream)>) -> Result<()> {
         show_request(request)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_provider_management_commands() {
+        assert_eq!(
+            provider_args("/provider add fast opencode openai/gpt", "add"),
+            Some(vec!["fast", "opencode", "openai/gpt"])
+        );
+        assert_eq!(
+            provider_args("/providers default fast", "default"),
+            Some(vec!["fast"])
+        );
+        assert_eq!(provider_args("/permission list", "add"), None);
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -10,6 +11,17 @@ pub struct Session {
     pub cwd: PathBuf,
     #[serde(default)]
     pub permitted_directories: Vec<PathBuf>,
+    #[serde(default)]
+    pub subagent_providers: BTreeMap<String, SubagentProvider>,
+    #[serde(default)]
+    pub default_subagent_provider: Option<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SubagentProvider {
+    pub driver: String,
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 pub fn state_dir() -> Result<PathBuf> {
@@ -47,10 +59,20 @@ pub async fn create_session(cwd: &Path, id: Option<&str>) -> Result<Session> {
         .map(str::to_owned)
         .unwrap_or_else(|| Uuid::new_v4().to_string());
     validate_session_id(&id)?;
+    let previous = if tokio::fs::try_exists(session_path(&id)?).await? {
+        Some(load_session(&id).await?)
+    } else {
+        None
+    };
     let session = Session {
         id,
         cwd: cwd.clone(),
         permitted_directories: vec![cwd],
+        subagent_providers: previous
+            .as_ref()
+            .map(|session| session.subagent_providers.clone())
+            .unwrap_or_default(),
+        default_subagent_provider: previous.and_then(|session| session.default_subagent_provider),
     };
     save_session(&session).await?;
     Ok(session)
@@ -85,6 +107,17 @@ pub fn validate_session_id(id: &str) -> Result<()> {
     Ok(())
 }
 
+pub fn validate_provider_name(name: &str) -> Result<()> {
+    anyhow::ensure!(!name.is_empty(), "provider name must not be empty");
+    anyhow::ensure!(name.len() <= 64, "provider name must be at most 64 bytes");
+    anyhow::ensure!(
+        name.chars()
+            .all(|character| character.is_ascii_alphanumeric() || "-_".contains(character)),
+        "provider name may contain only ASCII letters, numbers, '-' and '_'"
+    );
+    Ok(())
+}
+
 pub fn canonical_directory(path: &Path) -> Result<PathBuf> {
     let path = std::fs::canonicalize(path)
         .with_context(|| format!("cannot resolve {}", path.display()))?;
@@ -103,6 +136,27 @@ mod tests {
         assert!(validate_session_id("../escape").is_err());
         assert!(validate_session_id("contains spaces").is_err());
         assert!(validate_session_id(&"x".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn validates_provider_names() {
+        assert!(validate_provider_name("fast_opencode").is_ok());
+        assert!(validate_provider_name("claude-review").is_ok());
+        assert!(validate_provider_name("has spaces").is_err());
+        assert!(validate_provider_name("../escape").is_err());
+    }
+
+    #[test]
+    fn loads_sessions_created_before_provider_configuration() {
+        let session: Session = serde_json::from_value(serde_json::json!({
+            "id": "legacy",
+            "cwd": "/tmp",
+            "permitted_directories": ["/tmp"]
+        }))
+        .unwrap();
+
+        assert!(session.subagent_providers.is_empty());
+        assert!(session.default_subagent_provider.is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod approvals;
 mod config;
 mod mcp;
 mod sandbox;
+mod subagents;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
-use crate::{approvals, config, sandbox};
+use crate::{approvals, config, sandbox, subagents};
 
 const FOREGROUND_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -74,7 +74,7 @@ async fn dispatch(request: &Value) -> Result<Value> {
             "protocolVersion": "2025-06-18",
             "capabilities": {"tools": {"listChanged": false}},
             "serverInfo": {"name": "local-mcp", "version": env!("CARGO_PKG_VERSION")},
-            "instructions": "Every tool call requires the local-mcp session_id supplied by the user. Call session_info with that ID to inspect its working directory and sandbox roots."
+            "instructions": "Every tool call requires the local-mcp session_id supplied by the user. Call session_info with that ID to inspect its working directory, sandbox roots, and user-configured subagent providers. Subagent tools follow Codex's task-thread lifecycle: spawn_agent, send_message/followup_task, wait_agent/list_agents, then close_agent."
         })),
         "ping" => Ok(json!({})),
         "tools/list" => Ok(json!({"tools": tools()})),
@@ -85,13 +85,19 @@ async fn dispatch(request: &Value) -> Result<Value> {
 
 fn tools() -> Value {
     let mut tools = json!([
-        {"name":"session_info","description":"Show a local-mcp session's ID, working directory, and allowed sandbox roots.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"}},"required":["session_id"],"additionalProperties":false}},
+        {"name":"session_info","description":"Show a local-mcp session's ID, working directory, allowed sandbox roots, and configured subagent providers.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"}},"required":["session_id"],"additionalProperties":false}},
         {"name":"read_file","description":"Read a UTF-8 file from the local machine. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"}},"required":["session_id","path"]}},
         {"name":"get_image","description":"Read a local image and return it as MCP image content. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string","description":"Path to a PNG, JPEG, GIF, WebP, BMP, TIFF, or AVIF image."}},"required":["session_id","path"],"additionalProperties":false}},
         {"name":"list_directory","description":"List entries in a local directory. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"}},"required":["session_id","path"]}},
         {"name":"write_file","description":"Write a UTF-8 file in the Codex sandbox. Relative paths use the session working directory.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"path":{"type":"string"},"content":{"type":"string"}},"required":["session_id","path","content"]}},
         {"name":"execute","description":"Execute argv without a shell in the Codex sandbox. Returns the normal result when it finishes within 30 seconds; otherwise returns a job_id for use with poll_job or stop_job. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
         {"name":"start_command","description":"Start argv immediately as a background job in the Codex sandbox and return a job_id without waiting for completion. Network is disabled and approval is not required.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}},
+        {"name":"spawn_agent","description":"Spawn a configured CLI subagent for an independent task. The agent_type selects a provider configured by the user with /provider; omit it to use the default. Returns immediately with a canonical task name. The provider runs in read-only/plan mode with host network access and requires approval.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"task_name":{"type":"string","pattern":"^[a-z0-9_]+$"},"message":{"type":"string","minLength":1},"agent_type":{"type":"string","description":"Configured provider name from /provider list."},"cwd":{"type":"string"}},"required":["session_id","task_name","message"],"additionalProperties":false}},
+        {"name":"send_message","description":"Queue a message on an existing agent without triggering a new turn.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"target":{"type":"string"},"message":{"type":"string","minLength":1}},"required":["session_id","target","message"],"additionalProperties":false}},
+        {"name":"followup_task","description":"Send a follow-up message to an existing agent and trigger its next turn. If it is running, the message is queued for the next turn.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"target":{"type":"string"},"message":{"type":"string","minLength":1}},"required":["session_id","target","message"],"additionalProperties":false}},
+        {"name":"wait_agent","description":"Wait for any live agent to finish a turn. Returns a short update summary; use list_agents to inspect final content.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"timeout_ms":{"type":"integer","minimum":10000,"maximum":3600000}},"required":["session_id"],"additionalProperties":false}},
+        {"name":"list_agents","description":"List live agents, their configured provider type, status, and latest task message.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"}},"required":["session_id"],"additionalProperties":false}},
+        {"name":"close_agent","description":"Close an agent when it is no longer needed and return its previous status.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"target":{"type":"string"}},"required":["session_id","target"],"additionalProperties":false}},
         {"name":"poll_job","description":"Poll a background command returned by execute or start_command. Returns running while active, or the command result once completed.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"job_id":{"type":"string","format":"uuid"}},"required":["session_id","job_id"],"additionalProperties":false}},
         {"name":"stop_job","description":"Stop a background command returned by execute or start_command.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"job_id":{"type":"string","format":"uuid"}},"required":["session_id","job_id"],"additionalProperties":false}},
         {"name":"without_sandbox","description":"Execute argv directly on the host with full user permissions and network access. Every call requires approval unless the session is in yolo mode.","inputSchema":{"type":"object","properties":{"session_id":{"type":"string","format":"uuid"},"command":{"type":"array","items":{"type":"string"},"minItems":1},"cwd":{"type":"string"}},"required":["session_id","command"]}}
@@ -161,6 +167,22 @@ async fn call_tool(params: &Value) -> Result<Value> {
         "write_file" => write_file(&args, &session).await,
         "execute" => execute(&args, &session).await,
         "start_command" => start_command(&args, &session).await,
+        "spawn_agent" => text_result(serde_json::to_string(
+            &subagents::spawn(&session, &args).await?,
+        )?),
+        "send_message" => text_result(serde_json::to_string(
+            &subagents::send_message(&session, &args, false).await?,
+        )?),
+        "followup_task" => text_result(serde_json::to_string(
+            &subagents::send_message(&session, &args, true).await?,
+        )?),
+        "wait_agent" => text_result(serde_json::to_string(
+            &subagents::wait(&session, &args).await?,
+        )?),
+        "list_agents" => text_result(serde_json::to_string(&subagents::list(&session).await?)?),
+        "close_agent" => text_result(serde_json::to_string(
+            &subagents::close(&session, &args).await?,
+        )?),
         "poll_job" => poll_job(&args, &session).await,
         "stop_job" => stop_job(&args, &session).await,
         "without_sandbox" => without_sandbox(&args, &session).await,
@@ -587,6 +609,28 @@ mod tests {
     fn quotes_command_arguments_for_activity_display() {
         assert_eq!(shell_word("README.md"), "README.md");
         assert_eq!(shell_word("hello world"), "\"hello world\"");
+    }
+
+    #[test]
+    fn exposes_codex_style_subagent_lifecycle() {
+        let tools = tools();
+        let names = tools
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .collect::<Vec<_>>();
+        for name in [
+            "spawn_agent",
+            "send_message",
+            "followup_task",
+            "wait_agent",
+            "list_agents",
+            "close_agent",
+        ] {
+            assert!(names.contains(&name));
+        }
+        assert!(!names.contains(&"call_subagent"));
     }
 
     #[tokio::test]

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -128,6 +128,15 @@ pub async fn run_unrestricted(
     cwd: &Path,
     stdin: Option<&[u8]>,
 ) -> Result<Output> {
+    run_unrestricted_with_env(command, cwd, stdin, &[]).await
+}
+
+pub async fn run_unrestricted_with_env(
+    command: &[String],
+    cwd: &Path,
+    stdin: Option<&[u8]>,
+    environment: &[(String, String)],
+) -> Result<Output> {
     anyhow::ensure!(!command.is_empty(), "command must not be empty");
     let cwd = std::fs::canonicalize(cwd)
         .with_context(|| format!("cannot resolve cwd {}", cwd.display()))?;
@@ -136,6 +145,7 @@ pub async fn run_unrestricted(
         .kill_on_drop(true)
         .args(&command[1..])
         .current_dir(cwd)
+        .envs(environment.iter().map(|(key, value)| (key, value)))
         .stdin(if stdin.is_some() {
             Stdio::piped()
         } else {
@@ -168,6 +178,32 @@ fn safe_environment() -> HashMap<String, String> {
                 .map(|value| (name.to_owned(), value))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod unrestricted_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unrestricted_command_receives_environment_overrides() {
+        let command = vec![
+            "sh".to_owned(),
+            "-c".to_owned(),
+            "printf %s \"$LOCAL_MCP_SUBAGENT_TEST\"".to_owned(),
+        ];
+        let environment = vec![("LOCAL_MCP_SUBAGENT_TEST".to_owned(), "injected".to_owned())];
+        let output = run_unrestricted_with_env(
+            &command,
+            &std::env::current_dir().unwrap(),
+            None,
+            &environment,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(output.status, 0);
+        assert_eq!(output.stdout, "injected");
+    }
 }
 
 #[cfg(all(test, target_os = "macos"))]

--- a/src/subagents.rs
+++ b/src/subagents.rs
@@ -1,0 +1,515 @@
+use std::collections::{HashMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::{Value, json};
+use tokio::task::JoinHandle;
+
+use crate::config::{Session, SubagentProvider};
+use crate::{approvals, sandbox};
+
+const DEFAULT_WAIT_MS: u64 = 10_000;
+const MAX_WAIT_MS: u64 = 3_600_000;
+const MAX_OPEN_AGENTS: usize = 4;
+
+struct Invocation {
+    command: Vec<String>,
+    environment: Vec<(String, String)>,
+}
+
+struct Agent {
+    session_id: String,
+    task_name: String,
+    provider_name: String,
+    provider: SubagentProvider,
+    cwd: PathBuf,
+    messages: Vec<(String, String)>,
+    pending: VecDeque<String>,
+    trigger_pending: bool,
+    handle: Option<JoinHandle<Result<String>>>,
+    completion: Option<std::result::Result<String, String>>,
+    closed: bool,
+}
+
+fn agents() -> &'static Mutex<HashMap<String, Agent>> {
+    static AGENTS: OnceLock<Mutex<HashMap<String, Agent>>> = OnceLock::new();
+    AGENTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn key(session_id: &str, task_name: &str) -> String {
+    format!("{session_id}/{task_name}")
+}
+
+pub async fn spawn(session: &Session, args: &Value) -> Result<Value> {
+    let task_name = required_string(args, "task_name")?;
+    validate_task_name(task_name)?;
+    let message = required_message(args)?;
+    let (provider_name, provider) =
+        select_provider(session, args.get("agent_type").and_then(Value::as_str))?;
+    let cwd = resolve_cwd(args, &session.cwd)?;
+    let invocation = invocation(&provider, message)?;
+    anyhow::ensure!(
+        driver_available(&invocation.command[0]),
+        "{} CLI is not installed or is not in PATH",
+        provider.driver
+    );
+    {
+        let agents = agents().lock().unwrap();
+        anyhow::ensure!(
+            !agents.contains_key(&key(&session.id, task_name)),
+            "agent task already exists: {task_name}"
+        );
+        let open = agents
+            .values()
+            .filter(|agent| agent.session_id == session.id && !agent.closed)
+            .count();
+        anyhow::ensure!(
+            open < MAX_OPEN_AGENTS,
+            "maximum of {MAX_OPEN_AGENTS} open agents reached"
+        );
+    }
+    let model = provider.model.as_deref().unwrap_or("provider default");
+    if !approvals::request(
+        &session.id,
+        "spawn_agent",
+        format!(
+            "task: {task_name}\nprovider: {provider_name} ({})\nmodel: {model}\nmode: read-only/plan\nmessage:\n{message}",
+            provider.driver
+        ),
+        cwd.clone(),
+    )
+    .await?
+    {
+        anyhow::bail!("user denied subagent spawn")
+    }
+
+    let handle = spawn_turn(&provider_name, &provider, message, &cwd)?;
+    agents().lock().unwrap().insert(
+        key(&session.id, task_name),
+        Agent {
+            session_id: session.id.clone(),
+            task_name: task_name.to_owned(),
+            provider_name: provider_name.to_owned(),
+            provider,
+            cwd,
+            messages: vec![("user".to_owned(), message.to_owned())],
+            pending: VecDeque::new(),
+            trigger_pending: false,
+            handle: Some(handle),
+            completion: None,
+            closed: false,
+        },
+    );
+    approvals::activity(
+        &session.id,
+        format!("Spawned {task_name} via {provider_name}"),
+        None,
+    )
+    .await;
+    Ok(json!({"task_name": task_name, "nickname": provider_name}))
+}
+
+pub async fn send_message(session: &Session, args: &Value, trigger_turn: bool) -> Result<Value> {
+    let target = required_string(args, "target")?;
+    let message = required_message(args)?;
+    collect_finished(&session.id).await?;
+    let mut agents = agents().lock().unwrap();
+    let agent = agents
+        .get_mut(&key(&session.id, target))
+        .context("unknown agent target")?;
+    anyhow::ensure!(!agent.closed, "agent is closed: {target}");
+    agent.pending.push_back(message.to_owned());
+    agent.trigger_pending |= trigger_turn;
+    if trigger_turn && agent.handle.is_none() {
+        start_pending_turn(agent)?;
+    }
+    Ok(json!({"target": target, "queued": true, "triggered": trigger_turn}))
+}
+
+pub async fn wait(session: &Session, args: &Value) -> Result<Value> {
+    let timeout_ms = args
+        .get("timeout_ms")
+        .map(|value| {
+            value
+                .as_u64()
+                .context("timeout_ms must be a positive integer")
+        })
+        .transpose()?
+        .unwrap_or(DEFAULT_WAIT_MS);
+    anyhow::ensure!(timeout_ms >= 10_000, "timeout_ms must be at least 10000");
+    anyhow::ensure!(
+        timeout_ms <= MAX_WAIT_MS,
+        "timeout_ms must be at most {MAX_WAIT_MS}"
+    );
+    collect_finished(&session.id).await?;
+    if !has_live_agents(&session.id) {
+        return Ok(json!({"message":"No live agents.","timed_out":false}));
+    }
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(timeout_ms);
+    loop {
+        let updated = collect_finished(&session.id).await?;
+        if !updated.is_empty() {
+            return Ok(json!({
+                "message": format!("Agent updates available: {}", updated.join(", ")),
+                "timed_out": false
+            }));
+        }
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return Ok(json!({"message":"Wait timed out.","timed_out":true}));
+        }
+        tokio::time::sleep(Duration::from_millis(50).min(deadline - now)).await;
+    }
+}
+
+pub async fn list(session: &Session) -> Result<Value> {
+    collect_finished(&session.id).await?;
+    let agents = agents().lock().unwrap();
+    let values = agents
+        .values()
+        .filter(|agent| agent.session_id == session.id && !agent.closed)
+        .map(|agent| {
+            json!({
+                "agent_name": agent.task_name,
+                "agent_type": agent.provider_name,
+                "agent_status": status(agent),
+                "last_task_message": agent.messages.iter().rev().find(|(role, _)| role == "user").map(|(_, text)| text)
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(json!({"agents": values}))
+}
+
+pub async fn close(session: &Session, args: &Value) -> Result<Value> {
+    let target = required_string(args, "target")?;
+    collect_finished(&session.id).await?;
+    let mut agents = agents().lock().unwrap();
+    let agent = agents
+        .get_mut(&key(&session.id, target))
+        .context("unknown agent target")?;
+    let previous_status = status(agent);
+    if let Some(handle) = agent.handle.take() {
+        handle.abort();
+    }
+    agent.closed = true;
+    agent.pending.clear();
+    Ok(json!({"previous_status": previous_status}))
+}
+
+fn has_live_agents(session_id: &str) -> bool {
+    agents()
+        .lock()
+        .unwrap()
+        .values()
+        .any(|agent| agent.session_id == session_id && !agent.closed)
+}
+
+async fn collect_finished(session_id: &str) -> Result<Vec<String>> {
+    let ready = {
+        let mut agents = agents().lock().unwrap();
+        agents
+            .iter_mut()
+            .filter(|(_, agent)| agent.session_id == session_id && !agent.closed)
+            .filter_map(|(key, agent)| {
+                agent
+                    .handle
+                    .as_ref()
+                    .is_some_and(JoinHandle::is_finished)
+                    .then(|| (key.clone(), agent.handle.take().unwrap()))
+            })
+            .collect::<Vec<_>>()
+    };
+    let mut updated = Vec::new();
+    for (agent_key, handle) in ready {
+        let result = handle
+            .await
+            .context("subagent task failed")?
+            .map_err(|error| format!("{error:#}"));
+        let mut agents = agents().lock().unwrap();
+        let Some(agent) = agents.get_mut(&agent_key) else {
+            continue;
+        };
+        match &result {
+            Ok(response) => agent
+                .messages
+                .push(("assistant".to_owned(), response.clone())),
+            Err(error) => agent
+                .messages
+                .push(("assistant".to_owned(), format!("Error: {error}"))),
+        }
+        agent.completion = Some(result);
+        updated.push(agent.task_name.clone());
+        if agent.trigger_pending {
+            start_pending_turn(agent)?;
+        }
+    }
+    Ok(updated)
+}
+
+fn start_pending_turn(agent: &mut Agent) -> Result<()> {
+    let message = agent.pending.drain(..).collect::<Vec<_>>().join("\n\n");
+    anyhow::ensure!(!message.is_empty(), "no queued message for agent");
+    let prompt = continuation_prompt(agent, &message);
+    agent.handle = Some(spawn_turn(
+        &agent.provider_name,
+        &agent.provider,
+        &prompt,
+        &agent.cwd,
+    )?);
+    agent.messages.push(("user".to_owned(), message));
+    agent.completion = None;
+    agent.trigger_pending = false;
+    Ok(())
+}
+
+fn continuation_prompt(agent: &Agent, message: &str) -> String {
+    let previous = agent
+        .messages
+        .iter()
+        .rev()
+        .take(4)
+        .rev()
+        .map(|(role, text)| {
+            let text = text.chars().take(12_000).collect::<String>();
+            format!("{role}: {text}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    format!(
+        "Continue the same delegated task using the prior context below. Remain in read-only analysis mode.\n\n{previous}\n\nuser: {message}"
+    )
+}
+
+fn status(agent: &Agent) -> Value {
+    if agent.closed {
+        Value::String("shutdown".to_owned())
+    } else if agent.handle.is_some() {
+        Value::String("running".to_owned())
+    } else if let Some(completion) = &agent.completion {
+        match completion {
+            Ok(response) => json!({"completed": response}),
+            Err(error) => json!({"errored": error}),
+        }
+    } else {
+        Value::String("interrupted".to_owned())
+    }
+}
+
+fn spawn_turn(
+    provider_name: &str,
+    provider: &SubagentProvider,
+    prompt: &str,
+    cwd: &Path,
+) -> Result<JoinHandle<Result<String>>> {
+    let invocation = invocation(provider, prompt)?;
+    let provider_name = provider_name.to_owned();
+    let model = provider.model.clone();
+    let cwd = cwd.to_owned();
+    Ok(tokio::spawn(async move {
+        sandbox::run_unrestricted_with_env(&invocation.command, &cwd, None, &invocation.environment)
+            .await
+            .and_then(|output| render_output(&provider_name, model.as_deref(), output))
+    }))
+}
+
+fn select_provider(
+    session: &Session,
+    requested: Option<&str>,
+) -> Result<(String, SubagentProvider)> {
+    let name = requested
+        .filter(|name| !name.trim().is_empty())
+        .map(str::to_owned)
+        .or_else(|| session.default_subagent_provider.clone())
+        .context("no agent_type supplied and no default provider configured; use /provider add")?;
+    let provider = session
+        .subagent_providers
+        .get(&name)
+        .with_context(|| format!("unknown configured provider: {name}"))?
+        .clone();
+    Ok((name, provider))
+}
+
+fn invocation(provider: &SubagentProvider, prompt: &str) -> Result<Invocation> {
+    anyhow::ensure!(!prompt.trim().is_empty(), "message must not be empty");
+    anyhow::ensure!(
+        prompt.len() <= 65_536,
+        "message must be at most 65536 bytes"
+    );
+    let mut environment = Vec::new();
+    let mut command = match provider.driver.as_str() {
+        "opencode" => vec![
+            "opencode", "run", "--pure", "--agent", "plan", "--format", "default",
+        ],
+        "codex" => vec![
+            "codex",
+            "exec",
+            "--ephemeral",
+            "--ignore-user-config",
+            "--sandbox",
+            "read-only",
+            "--color",
+            "never",
+        ],
+        "claude" => vec![
+            "claude",
+            "--print",
+            "--safe-mode",
+            "--strict-mcp-config",
+            "--tools",
+            "Read,Glob,Grep",
+            "--permission-mode",
+            "plan",
+            "--output-format",
+            "text",
+        ],
+        "gemini" => vec![
+            "gemini",
+            "--approval-mode",
+            "plan",
+            "--output-format",
+            "text",
+        ],
+        driver => anyhow::bail!("unsupported provider driver: {driver}"),
+    }
+    .into_iter()
+    .map(str::to_owned)
+    .collect::<Vec<_>>();
+    if provider.driver == "opencode" {
+        environment.push((
+            "OPENCODE_CONFIG_CONTENT".to_owned(),
+            json!({"agent":{"plan":{"permission":{"*":"deny","read":"allow","glob":"allow","grep":"allow","list":"allow","lsp":"allow","webfetch":"allow","websearch":"allow","edit":"deny","bash":"deny","task":"deny","external_directory":"deny","question":"deny"}}}}).to_string(),
+        ));
+    }
+    if let Some(model) = &provider.model {
+        command.extend(["--model".to_owned(), model.clone()]);
+    }
+    if provider.driver == "gemini" {
+        command.push("--prompt".to_owned());
+    }
+    command.push(prompt.to_owned());
+    Ok(Invocation {
+        command,
+        environment,
+    })
+}
+
+fn render_output(provider: &str, model: Option<&str>, output: sandbox::Output) -> Result<String> {
+    if output.status == 0 {
+        Ok(output.stdout.trim_end().to_owned())
+    } else {
+        anyhow::bail!(
+            json!({
+                "provider": provider,
+                "model": model,
+                "stdout": output.stdout.trim_end(),
+                "stderr": output.stderr.trim_end(),
+                "exit_code": output.status
+            })
+            .to_string()
+        )
+    }
+}
+
+pub fn driver_available(executable: &str) -> bool {
+    std::env::var_os("PATH").is_some_and(|paths| {
+        std::env::split_paths(&paths).any(|directory| directory.join(executable).is_file())
+    })
+}
+
+fn required_string<'a>(args: &'a Value, name: &str) -> Result<&'a str> {
+    args.get(name)
+        .and_then(Value::as_str)
+        .with_context(|| format!("missing {name}"))
+}
+
+fn required_message(args: &Value) -> Result<&str> {
+    let message = required_string(args, "message")?;
+    anyhow::ensure!(!message.trim().is_empty(), "message must not be empty");
+    Ok(message)
+}
+
+fn validate_task_name(name: &str) -> Result<()> {
+    anyhow::ensure!(!name.is_empty(), "task_name must not be empty");
+    anyhow::ensure!(name.len() <= 64, "task_name must be at most 64 bytes");
+    anyhow::ensure!(
+        name.chars().all(|character| character.is_ascii_lowercase()
+            || character.is_ascii_digit()
+            || character == '_'),
+        "task_name may contain only lowercase ASCII letters, digits, and underscores"
+    );
+    Ok(())
+}
+
+fn resolve_cwd(args: &Value, session_cwd: &Path) -> Result<PathBuf> {
+    let path = args
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                session_cwd.join(path)
+            }
+        })
+        .unwrap_or_else(|| session_cwd.to_owned());
+    std::fs::canonicalize(&path).with_context(|| format!("cannot resolve cwd {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn session() -> Session {
+        Session {
+            id: "test".to_owned(),
+            cwd: std::env::current_dir().unwrap(),
+            permitted_directories: Vec::new(),
+            subagent_providers: BTreeMap::from([(
+                "fast".to_owned(),
+                SubagentProvider {
+                    driver: "opencode".to_owned(),
+                    model: Some("openai/test".to_owned()),
+                },
+            )]),
+            default_subagent_provider: Some("fast".to_owned()),
+        }
+    }
+
+    #[test]
+    fn resolves_configured_provider_and_builds_safe_command() {
+        let (_, provider) = select_provider(&session(), None).unwrap();
+        let invocation = invocation(&provider, "review this repository").unwrap();
+        assert!(invocation.command.starts_with(&[
+            "opencode".to_owned(),
+            "run".to_owned(),
+            "--pure".to_owned()
+        ]));
+        assert!(
+            invocation
+                .command
+                .windows(2)
+                .any(|items| items == ["--model", "openai/test"])
+        );
+        let config: Value = serde_json::from_str(&invocation.environment[0].1).unwrap();
+        assert_eq!(config["agent"]["plan"]["permission"]["*"], "deny");
+    }
+
+    #[test]
+    fn validates_codex_style_task_names() {
+        assert!(validate_task_name("security_review_1").is_ok());
+        assert!(validate_task_name("HasCaps").is_err());
+        assert!(validate_task_name("has-hyphen").is_err());
+    }
+
+    #[test]
+    fn requires_configured_provider() {
+        let mut session = session();
+        session.default_subagent_provider = None;
+        assert!(select_provider(&session, None).is_err());
+        assert!(select_provider(&session, Some("missing")).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- add a Codex-style subagent lifecycle with `spawn_agent`, `send_message`, `followup_task`, `wait_agent`, `list_agents`, and `close_agent`
- let users configure named OpenCode, Codex, Claude Code, and Gemini CLI providers from the `local-mcp start` screen with `/provider` commands
- persist provider selection per stable session ID and allow `spawn_agent.agent_type` to select a configured provider
- run provider CLIs in read-only/plan modes, require approval for the initial host/network invocation, and inherit that approval for follow-up turns
- document setup, safety modes, and provider-specific model values

## Why

Subagent delegation should match Codex's task-thread model while leaving provider choice and authorization under the local user's control. This keeps provider credentials and permissions in the user's CLI environment instead of hard-coding an LLM backend in the MCP server.

## Validation

- `cargo test --all-targets` (15 tests passed)
- `cargo clippy --all-targets -- -D warnings -A clippy::cloned-ref-to-slice-refs`
- `git diff --check`

External authenticated LLM calls were intentionally not made during validation; provider command construction and safety configuration are covered by tests.